### PR TITLE
feat: integrate recent messages

### DIFF
--- a/src-tauri/src/irc/message/commands.rs
+++ b/src-tauri/src/irc/message/commands.rs
@@ -326,6 +326,8 @@ pub struct PrivmsgMessage {
     pub name_color: String,
     pub emotes: Vec<Emote>,
     pub message_id: String,
+    pub deleted: bool,
+    pub is_recent: bool,
     pub server_timestamp: u64,
     pub source: IrcMessage,
 }
@@ -367,6 +369,10 @@ impl TryFrom<IrcMessage> for PrivmsgMessage {
             is_highlighted: msg_id
                 .map(|id| id == "highlighted-message")
                 .unwrap_or_default(),
+            deleted: source
+                .try_get_optional_bool("rm-deleted")?
+                .unwrap_or_default(),
+            is_recent: source.tags.0.contains_key("rm-received-ts"),
             source,
         })
     }
@@ -467,6 +473,8 @@ pub struct UserNoticeMessage {
     pub emotes: Vec<Emote>,
     pub name_color: String,
     pub message_id: String,
+    pub deleted: bool,
+    pub is_recent: bool,
     pub server_timestamp: u64,
     pub source: IrcMessage,
 }
@@ -697,6 +705,10 @@ impl TryFrom<IrcMessage> for UserNoticeMessage {
             emotes,
             name_color: source.try_get_color("color")?.to_owned(),
             message_id: source.try_get_nonempty_tag_value("id")?.to_owned(),
+            deleted: source
+                .try_get_optional_bool("rm-deleted")?
+                .unwrap_or_default(),
+            is_recent: source.tags.0.contains_key("rm-received-ts"),
             server_timestamp: source.try_get_timestamp("tmi-sent-ts")?.to_owned(),
             source,
         })

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -1,4 +1,5 @@
 pub mod bttv;
 pub mod ffz;
+pub mod recent_messages;
 pub mod seventv;
 pub mod twitch;

--- a/src-tauri/src/providers/recent_messages.rs
+++ b/src-tauri/src/providers/recent_messages.rs
@@ -11,6 +11,11 @@ struct RecentMessages {
 }
 
 pub async fn get_recent_messages(channel: String, limit: u32) -> Result<Vec<ServerMessage>, Error> {
+    // Return early as to not trigger wakeups
+    if limit == 0 {
+        return Ok(vec![]);
+    }
+
     let response: RecentMessages = HTTP
         .get(format!(
             "https://recent-messages.robotty.de/api/v2/recent-messages/{channel}?limit={limit}"

--- a/src-tauri/src/providers/recent_messages.rs
+++ b/src-tauri/src/providers/recent_messages.rs
@@ -1,0 +1,30 @@
+use serde::Deserialize;
+
+use crate::error::Error;
+use crate::irc::message::{IrcMessage, ServerMessage};
+use crate::HTTP;
+
+#[derive(Debug, Deserialize)]
+struct RecentMessages {
+    #[serde(default)]
+    messages: Vec<String>,
+}
+
+pub async fn get_recent_messages(channel: String, limit: u32) -> Result<Vec<ServerMessage>, Error> {
+    let response: RecentMessages = HTTP
+        .get(format!(
+            "https://recent-messages.robotty.de/api/v2/recent-messages/{channel}?limit={limit}"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let server_messages: Vec<_> = response
+        .messages
+        .into_iter()
+        .filter_map(|m| ServerMessage::try_from(IrcMessage::parse(&m).ok()?).ok())
+        .collect();
+
+    Ok(server_messages)
+}

--- a/src/lib/channel.svelte.ts
+++ b/src/lib/channel.svelte.ts
@@ -1,11 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
 import { SvelteMap } from "svelte/reactivity";
 import { replyTarget } from "./components/Input.svelte";
-import { UserMessage } from "./message";
 import type { Message } from "./message";
 import { settings } from "./settings";
 import type { JoinedChannel } from "./tauri";
 import type { Badge, BadgeSet, Stream } from "./twitch/api";
+import type { IrcMessage } from "./twitch/irc";
 import { User } from "./user";
 import { Viewer } from "./viewer.svelte";
 
@@ -21,6 +21,7 @@ export class Channel {
 	public readonly emotes = new SvelteMap<string, Emote>();
 	public readonly viewers = new SvelteMap<string, Viewer>();
 
+	public recentMessages = $state<IrcMessage[]>([]);
 	public messages = $state<Message[]>([]);
 
 	public constructor(
@@ -73,16 +74,11 @@ export class Channel {
 			.addEmotes(joined.emotes)
 			.setStream(joined.stream);
 
-		for (const message of joined.recent_messages) {
-			if (message.type === "privmsg" || message.type === "usernotice") {
-				channel.messages.push(new UserMessage(message));
-			}
-		}
-
 		const viewer = new Viewer(user);
 		viewer.broadcaster = true;
 
 		channel.viewers.set(user.username, viewer);
+		channel.recentMessages = joined.recent_messages;
 
 		return channel;
 	}

--- a/src/lib/channel.svelte.ts
+++ b/src/lib/channel.svelte.ts
@@ -64,7 +64,9 @@ export class Channel {
 	public static async join(login: string) {
 		const joined = await invoke<JoinedChannel>("join", {
 			login,
-			historyLimit: settings.state.historyLimit,
+			historyLimit: settings.state.historyEnabled
+				? settings.state.historyLimit
+				: 0,
 		});
 
 		const user = new User(joined.user);

--- a/src/lib/components/Chat.svelte
+++ b/src/lib/components/Chat.svelte
@@ -76,15 +76,15 @@
 				{/if}
 
 				{#if message.isRecent && (!next || (next?.isUser() && !next.isRecent))}
-					<div class="relative px-3.5">
+					<div class="text-twitch relative px-3.5">
 						<Separator.Root
-							class="my-4 h-px w-full rounded-full bg-red-500"
+							class="my-4 h-px w-full rounded-full bg-current"
 						/>
 
 						<div
-							class="bg-background absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 px-2 text-xs font-semibold text-red-500 uppercase"
+							class="bg-background absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 px-2 text-xs font-semibold uppercase"
 						>
-							New messages
+							Live messages
 						</div>
 					</div>
 				{/if}

--- a/src/lib/components/Chat.svelte
+++ b/src/lib/components/Chat.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { Separator } from "bits-ui";
 	import { VList } from "virtua/svelte";
 	import type { Message } from "$lib/message";
 	import { app } from "$lib/state.svelte";
@@ -62,13 +63,31 @@
 		onscroll={handleScroll}
 		bind:this={list}
 	>
-		{#snippet children(message: Message)}
+		{#snippet children(message: Message, i)}
 			{#if !message.isUser()}
 				<SystemMessage {message} />
-			{:else if message.event}
-				<Notification {message} />
 			{:else}
-				<UserMessage {message} />
+				{@const next = app.active.messages.at(i + 1)}
+
+				{#if message.event}
+					<Notification {message} />
+				{:else}
+					<UserMessage {message} />
+				{/if}
+
+				{#if message.isRecent && (!next || (next?.isUser() && !next.isRecent))}
+					<div class="relative px-3.5">
+						<Separator.Root
+							class="my-4 h-px w-full rounded-full bg-red-500"
+						/>
+
+						<div
+							class="bg-background absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 px-2 text-xs font-semibold text-red-500 uppercase"
+						>
+							New messages
+						</div>
+					</div>
+				{/if}
 			{/if}
 		{/snippet}
 	</VList>

--- a/src/lib/components/settings/Chat.svelte
+++ b/src/lib/components/settings/Chat.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { Label, Slider, Switch } from "bits-ui";
+	import { settings } from "$lib/settings";
+</script>
+
+<div class="space-y-6">
+	<h1 class="text-2xl font-semibold">Chat</h1>
+
+	<h2 class="text-xl font-medium">Messages</h2>
+
+	<div>
+		<h3 class="mb-2 text-lg font-medium">Message History Limit</h3>
+
+		<p class="text-muted-foreground mb-4 text-sm">
+			This feature uses a
+			<a
+				class="text-twitch-link"
+				href="https://recent-messages.robotty.de/">third-party API</a
+			> that temporarily stores the messages sent in joined channels. To opt-out,
+			disable this setting.
+		</p>
+
+		<Label.Root class="mb-6 flex items-center">
+			<Switch.Root
+				class="data-[state=checked]:bg-twitch data-[state=unchecked]:bg-input h-6 w-11 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors"
+				bind:checked={settings.state.historyEnabled}
+			>
+				<Switch.Thumb
+					class="pointer-events-none block size-4.5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0.5"
+				/>
+			</Switch.Root>
+
+			<span class="ml-2 text-sm font-medium">Enable</span>
+		</Label.Root>
+
+		<p
+			class={[
+				"text-muted-foreground mb-6 text-sm",
+				!settings.state.historyEnabled && "opacity-50",
+			]}
+		>
+			Change how many previous messages to load when joining a channel.
+		</p>
+
+		<Slider.Root
+			class="relative flex items-center data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+			type="single"
+			min={0}
+			max={800}
+			step={50}
+			disabled={!settings.state.historyEnabled}
+			bind:value={settings.state.historyLimit}
+		>
+			<div
+				class="bg-input relative h-2 w-full rounded-full hover:cursor-pointer"
+			>
+				<Slider.Range class="bg-twitch absolute h-full rounded-full" />
+			</div>
+
+			<Slider.Thumb
+				class="flex size-5 justify-center rounded-full bg-white hover:cursor-grab active:scale-110 active:cursor-grabbing"
+				index={0}
+			>
+				<div class="mt-7 text-center text-xs font-medium">
+					{settings.state.historyLimit}
+				</div>
+			</Slider.Thumb>
+		</Slider.Root>
+	</div>
+</div>

--- a/src/lib/components/settings/Settings.svelte
+++ b/src/lib/components/settings/Settings.svelte
@@ -1,14 +1,24 @@
 <script lang="ts">
+	import MessageSquare from "@lucide/svelte/icons/message-square";
 	import MonitorCog from "@lucide/svelte/icons/monitor-cog";
 	import X from "@lucide/svelte/icons/x";
 	import { Dialog, Tabs } from "bits-ui";
+	import Chat from "./Chat.svelte";
 	import General from "./General.svelte";
+	import { settings } from "$lib/settings";
 
 	let { open = $bindable(false) } = $props();
 
 	const categories = [
 		{ name: "General", icon: MonitorCog, component: General },
+		{ name: "Chat", icon: MessageSquare, component: Chat },
 	];
+
+	$effect(() => {
+		void open;
+
+		settings.saveNow();
+	});
 </script>
 
 <svelte:document
@@ -27,7 +37,7 @@
 				orientation="vertical"
 				value="General"
 			>
-				<nav class="bg-sidebar h-full w-48 border-r p-2">
+				<nav class="bg-sidebar h-full min-w-44 border-r p-2">
 					<Dialog.Title
 						class="text-muted-foreground mb-2 text-xs font-semibold uppercase"
 					>

--- a/src/lib/handlers/index.ts
+++ b/src/lib/handlers/index.ts
@@ -1,9 +1,10 @@
+import type { IrcMessageMap } from "$lib/twitch/irc";
 import clearmsg from "./clearmsg";
 import type { Handler } from "./helper";
 import privmsg from "./privmsg";
 import usernotice from "./usernotice";
 
-export const handlers = new Map<string, Handler<any>>();
+export const handlers = new Map<string, Handler<keyof IrcMessageMap>>();
 
 function register(handler: Handler<any>) {
 	handlers.set(handler.name, handler);

--- a/src/lib/message/message.ts
+++ b/src/lib/message/message.ts
@@ -1,4 +1,4 @@
-import type { BaseUserMessage } from "$lib/twitch/irc";
+import type { BaseUserMessage, UserNoticeMessage } from "$lib/twitch/irc";
 import { formatTime } from "$lib/util";
 import type { SystemMessageData, UserMessage } from "./";
 
@@ -40,7 +40,12 @@ export abstract class Message {
 
 	public get text(): string {
 		if (this.isUser()) {
-			return this.data.message_text;
+			// message_text should only be possibly null if it's a USERNOTICE,
+			// in which case we can assume system_message is present
+			return (
+				this.data.message_text ??
+				(this.data as UserNoticeMessage).system_message
+			);
 		}
 
 		return (this.data as SystemMessageData).text;

--- a/src/lib/message/user-message.svelte.ts
+++ b/src/lib/message/user-message.svelte.ts
@@ -44,6 +44,7 @@ export class UserMessage extends Message {
 	) {
 		super(data);
 
+		this.#deleted = data.deleted;
 		this.fragments = this.#fragment();
 	}
 
@@ -100,6 +101,13 @@ export class UserMessage extends Message {
 	 */
 	public get isAction() {
 		return "is_action" in this.data ? this.data.is_action : false;
+	}
+
+	/**
+	 * Whether the message was retreived by the `recent-messages` API.
+	 */
+	public get isRecent() {
+		return this.data.is_recent;
 	}
 
 	/**

--- a/src/lib/message/user-message.svelte.ts
+++ b/src/lib/message/user-message.svelte.ts
@@ -31,7 +31,7 @@ interface TextSegment extends Range {
  * notifications received by `USERNOTICE` commands.
  *
  * In either case, both share enough common data that they can be categorized
- * as "user" messages. Properties such as {@linkcode announcement} can be
+ * as "user" messages. The {@linkcode UserMessage.event event} property can be
  * checked to differentiate the two.
  */
 export class UserMessage extends Message {

--- a/src/lib/message/user-message.svelte.ts
+++ b/src/lib/message/user-message.svelte.ts
@@ -138,7 +138,7 @@ export class UserMessage extends Message {
 
 	#fragment() {
 		const fragments: Fragment[] = [];
-		const message = this.data.message_text;
+		const message = this.text;
 
 		const chars = Array.from(message);
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -6,6 +6,7 @@ export interface Settings {
 	user: { id: string; token: string } | null;
 	lastJoined: string | null;
 	timeFormat: "auto" | "12" | "24";
+	historyEnabled: boolean;
 	historyLimit: number;
 }
 
@@ -13,5 +14,6 @@ export const settings = new RuneStore<Settings>("settings", {
 	user: null,
 	lastJoined: null,
 	timeFormat: "auto",
+	historyEnabled: true,
 	historyLimit: 250,
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -6,10 +6,12 @@ export interface Settings {
 	user: { id: string; token: string } | null;
 	lastJoined: string | null;
 	timeFormat: "auto" | "12" | "24";
+	historyLimit: number;
 }
 
 export const settings = new RuneStore<Settings>("settings", {
 	user: null,
 	lastJoined: null,
 	timeFormat: "auto",
+	historyLimit: 250,
 });

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,5 +1,6 @@
 import type { Emote } from "./channel.svelte";
 import type { BadgeSet, User as HelixUser, Stream } from "./twitch/api";
+import type { IrcMessage } from "./twitch/irc";
 
 export interface UserEmote {
 	set_id: string;
@@ -23,6 +24,7 @@ export interface FullChannel {
 
 export interface JoinedChannel extends FullChannel {
 	id: string;
+	recent_messages: IrcMessage[];
 	emotes: Record<string, Emote>;
 	badges: BadgeSet[];
 }

--- a/src/lib/twitch/irc.ts
+++ b/src/lib/twitch/irc.ts
@@ -48,6 +48,8 @@ export interface BaseUserMessage {
 	name_color: string;
 	emotes: Emote[];
 	message_id: string;
+	deleted: boolean;
+	is_recent: boolean;
 	server_timestamp: string;
 }
 

--- a/src/lib/twitch/irc.ts
+++ b/src/lib/twitch/irc.ts
@@ -42,7 +42,6 @@ export interface Emote {
 export interface BaseUserMessage {
 	channel_login: string;
 	channel_id: string;
-	message_text: string;
 	sender: BasicUser;
 	badges: Badge[];
 	badge_info: Badge[];
@@ -70,6 +69,7 @@ export interface Reply {
 
 export interface PrivmsgMessage extends BaseUserMessage {
 	type: "privmsg";
+	message_text: string;
 	reply: Reply | null;
 	is_action: boolean;
 	is_first_msg: boolean;
@@ -161,6 +161,7 @@ export type UserNoticeEvent =
 
 export interface UserNoticeMessage extends BaseUserMessage {
 	type: "usernotice";
+	message_text: string | null;
 	system_message: string;
 	event: UserNoticeEvent;
 	event_id: string;

--- a/src/routes/[channel]/+page.svelte
+++ b/src/routes/[channel]/+page.svelte
@@ -2,8 +2,9 @@
 	import { Channel } from "$lib/channel.svelte";
 	import Chat from "$lib/components/Chat.svelte";
 	import Input, { replyTarget } from "$lib/components/Input.svelte";
+	import { handlers } from "$lib/handlers";
 	import { SystemMessage } from "$lib/message";
-	import { settings } from "$lib/settings.js";
+	import { settings } from "$lib/settings";
 	import { app } from "$lib/state.svelte";
 
 	const { data } = $props();
@@ -16,11 +17,16 @@
 
 	async function join() {
 		const channel = await Channel.join(data.channel);
+		app.active = channel;
 
 		channel.addEmotes(app.globalEmotes);
-		// channel.messages = [SystemMessage.joined(channel.user)];
+		channel.messages = [SystemMessage.joined(channel.user)];
 
-		app.active = channel;
+		for (const message of channel.recentMessages) {
+			const handler = handlers.get(message.type);
+			await handler?.handle(message);
+		}
+
 		settings.state.lastJoined = data.channel;
 	}
 

--- a/src/routes/[channel]/+page.svelte
+++ b/src/routes/[channel]/+page.svelte
@@ -18,7 +18,7 @@
 		const channel = await Channel.join(data.channel);
 
 		channel.addEmotes(app.globalEmotes);
-		channel.messages = [SystemMessage.joined(channel.user)];
+		// channel.messages = [SystemMessage.joined(channel.user)];
 
 		app.active = channel;
 		settings.state.lastJoined = data.channel;


### PR DESCRIPTION
Still to do:

- [x] Handle other message types
- [x] Handle `rm-deleted` (and maybe `rm-received-ts`) tags
- [ ] Handle possible duplicates (will this ever happen?)
- [x] Add message history limit setting
- [ ] ~~Add opt-in/out setting~~ (redundant with above)
- [ ] ~~Fix join system message timing~~

Errors are silently ignored since the docs state that they don't indicate a hard failure and may still return messages. Other internal errors are also ignored, defaulting to an empty vec.