### PR TITLE
feat: eventsub

### DIFF
--- a/src-tauri/src/api/chat.rs
+++ b/src-tauri/src/api/chat.rs
@@ -107,7 +107,7 @@ pub async fn leave(state: State<'_, Mutex<AppState>>, channel: String) -> Result
     let state = state.lock().await;
 
     if let Some(eventsub) = state.eventsub.clone() {
-        eventsub.unsubscribe_all().await?;
+        eventsub.unsubscribe_all(&channel).await?;
     }
 
     if let Some(ref irc) = state.irc {

--- a/src-tauri/src/api/chat.rs
+++ b/src-tauri/src/api/chat.rs
@@ -3,8 +3,10 @@ use serde::Serialize;
 use serde_json::json;
 use tauri::async_runtime::{self, Mutex};
 use tauri::{AppHandle, Emitter, State};
+use twitch_api::eventsub::EventType;
 use twitch_api::helix::chat::BadgeSet;
 use twitch_api::helix::streams::Stream;
+use twitch_api::twitch_oauth2::TwitchToken;
 
 use super::channels::get_stream;
 use super::users::{get_user_from_login, User};
@@ -79,8 +81,14 @@ pub async fn join(
 
     if let Some(eventsub) = eventsub {
         eventsub
-            .subscribe_all(&[("channel.moderate", &json!({}))])
-            .await?;
+            .subscribe(
+                EventType::ChannelModerate,
+                json!({
+                    "broadcaster_user_id": broadcaster_id,
+                    "moderator_user_id": token.user_id()
+                }),
+            )
+            .await?
     }
 
     irc.join(login.to_string());

--- a/src-tauri/src/api/chat.rs
+++ b/src-tauri/src/api/chat.rs
@@ -1,12 +1,9 @@
 use anyhow::anyhow;
 use serde::Serialize;
-use serde_json::json;
 use tauri::async_runtime::{self, Mutex};
 use tauri::{AppHandle, Emitter, State};
-use twitch_api::eventsub::EventType;
 use twitch_api::helix::chat::BadgeSet;
 use twitch_api::helix::streams::Stream;
-use twitch_api::twitch_oauth2::TwitchToken;
 
 use super::channels::get_stream;
 use super::users::{get_user_from_login, User};
@@ -78,18 +75,6 @@ pub async fn join(
     });
 
     global_badges.extend(channel_badges);
-
-    if let Some(eventsub) = eventsub {
-        eventsub
-            .subscribe(
-                EventType::ChannelModerate,
-                json!({
-                    "broadcaster_user_id": broadcaster_id,
-                    "moderator_user_id": token.user_id()
-                }),
-            )
-            .await?
-    }
 
     irc.join(login.to_string());
 

--- a/src-tauri/src/api/chat.rs
+++ b/src-tauri/src/api/chat.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use serde::Serialize;
+use serde_json::json;
 use tauri::async_runtime::{self, Mutex};
 use tauri::{AppHandle, Emitter, State};
 use twitch_api::helix::chat::BadgeSet;
@@ -29,7 +30,7 @@ pub async fn join(
     login: String,
     history_limit: u32,
 ) -> Result<JoinedChannel, Error> {
-    let (helix, token, irc) = {
+    let (helix, token, irc, eventsub) = {
         let state = state.lock().await;
 
         let token = state
@@ -41,7 +42,12 @@ pub async fn join(
             return Err(Error::Generic(anyhow!("No IRC connection")));
         };
 
-        (state.helix.clone(), token.clone(), irc)
+        (
+            state.helix.clone(),
+            token.clone(),
+            irc,
+            state.eventsub.clone(),
+        )
     };
 
     let user = get_user_from_login(state.clone(), login)
@@ -71,6 +77,12 @@ pub async fn join(
 
     global_badges.extend(channel_badges);
 
+    if let Some(eventsub) = eventsub {
+        eventsub
+            .subscribe_all(&[("channel.moderate", &json!({}))])
+            .await?;
+    }
+
     irc.join(login.to_string());
 
     Ok(JoinedChannel {
@@ -85,6 +97,10 @@ pub async fn join(
 #[tauri::command]
 pub async fn leave(state: State<'_, Mutex<AppState>>, channel: String) -> Result<(), Error> {
     let state = state.lock().await;
+
+    if let Some(eventsub) = state.eventsub.clone() {
+        eventsub.unsubscribe_all().await?;
+    }
 
     if let Some(ref irc) = state.irc {
         irc.part(channel);

--- a/src-tauri/src/api/mod.rs
+++ b/src-tauri/src/api/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use serde::Deserialize;
 use tauri::async_runtime::Mutex;
 use tauri::State;
 use twitch_api::twitch_oauth2::{AccessToken, UserToken};
@@ -10,6 +11,11 @@ pub mod channels;
 pub mod chat;
 pub mod moderation;
 pub mod users;
+
+#[derive(Debug, Deserialize)]
+pub struct Response<T> {
+    pub data: T,
+}
 
 pub async fn get_access_token<'a>(state: &'a AppState) -> Result<&'a UserToken, Error> {
     state

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,4 +1,5 @@
 use serde::{Serialize, Serializer};
+use tokio_tungstenite::tungstenite;
 use twitch_api::helix::ClientRequestError;
 
 #[derive(Debug, thiserror::Error)]
@@ -11,6 +12,9 @@ pub enum Error {
 
     #[error(transparent)]
     Helix(#[from] ClientRequestError<reqwest::Error>),
+
+    #[error(transparent)]
+    WebSocket(#[from] tungstenite::Error),
 }
 
 impl Serialize for Error {

--- a/src-tauri/src/eventsub/client.rs
+++ b/src-tauri/src/eventsub/client.rs
@@ -1,12 +1,17 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
-use futures::future::try_join_all;
+use anyhow::anyhow;
+use futures::future::join_all;
 use futures::{SinkExt, StreamExt};
+use serde::de::{DeserializeOwned, Error as DeError};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
-use twitch_api::eventsub::EventSubSubscription;
+use twitch_api::eventsub::{EventSubSubscription, EventType};
 use twitch_api::twitch_oauth2::{TwitchToken, UserToken};
 use twitch_api::HelixClient;
 
@@ -16,61 +21,226 @@ use crate::HTTP;
 
 const TWITCH_EVENTSUB_WS_URI: &str = "wss://eventsub.wss.twitch.tv/ws";
 
-#[derive(Clone)]
-pub struct EventSubClient<'a> {
-    helix: &'a HelixClient<'static, reqwest::Client>,
-    token: &'a UserToken,
-    session_id: Option<String>,
-    subscriptions: HashMap<String, String>,
+const V2_EVENTS: [EventType; 4] = [
+    EventType::AutomodMessageHold,
+    EventType::AutomodMessageUpdate,
+    EventType::ChannelModerate,
+    EventType::ChannelPointsAutomaticRewardRedemptionAdd,
+];
+
+#[derive(Debug, Deserialize)]
+enum MessageType {
+    #[serde(rename = "session_welcome")]
+    Welcome,
+    #[serde(rename = "notification")]
+    Notification,
+    #[serde(rename = "session_reconnect")]
+    Reconnect,
+    #[serde(rename = "revocation")]
+    Revocation,
+    #[serde(rename = "session_keepalive")]
+    Keepalive,
 }
 
-impl<'a> EventSubClient<'a> {
-    pub fn new(
-        helix: &'a HelixClient<'static, reqwest::Client>,
-        token: &'a UserToken,
-    ) -> (mpsc::UnboundedReceiver<()>, Self) {
-        let (sender, receiver) = mpsc::unbounded_channel::<()>();
+#[derive(Debug, Deserialize)]
+pub struct MessageMetadata {
+    message_type: MessageType,
+}
 
-        (
-            receiver,
-            Self {
-                helix,
-                token,
-                session_id: None,
-                subscriptions: HashMap::new(),
-            },
-        )
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Subscription {
+    pub id: String,
+    #[serde(rename(serialize = "type"))]
+    kind: EventType,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WebSocketSession {
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SessionPayload {
+    session: WebSocketSession,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NotificationPayload {
+    subscription: Subscription,
+    event: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RevocationPayload {
+    pub subscription: Subscription,
+}
+
+#[derive(Debug)]
+pub enum WebSocketMessage {
+    Welcome(SessionPayload),
+    Notification(NotificationPayload),
+    Reconnect(SessionPayload),
+    Revocation(RevocationPayload),
+    Keepalive,
+}
+
+#[derive(Deserialize)]
+struct MessageDeserializer {
+    metadata: MessageMetadata,
+    payload: Option<serde_json::Value>,
+}
+
+fn parse_payload<T, E>(payload: serde_json::Value) -> Result<T, E>
+where
+    T: DeserializeOwned,
+    E: DeError,
+{
+    T::deserialize(payload).map_err(DeError::custom)
+}
+
+impl<'de> Deserialize<'de> for WebSocketMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let message = MessageDeserializer::deserialize(deserializer)?;
+        let payload = message.payload.unwrap_or(serde_json::Value::Null);
+
+        match message.metadata.message_type {
+            MessageType::Welcome => Ok(Self::Welcome(parse_payload(payload)?)),
+            MessageType::Keepalive => Ok(Self::Keepalive),
+            MessageType::Notification => Ok(Self::Notification(parse_payload(payload)?)),
+            MessageType::Reconnect => Ok(Self::Reconnect(parse_payload(payload)?)),
+            MessageType::Revocation => Ok(Self::Revocation(parse_payload(payload)?)),
+        }
+    }
+}
+
+pub struct EventSubClient {
+    helix: Arc<HelixClient<'static, reqwest::Client>>,
+    pub token: Arc<UserToken>,
+    session_id: Arc<Mutex<Option<String>>>,
+    subscriptions: Arc<Mutex<HashMap<String, String>>>,
+    connected: Arc<AtomicBool>,
+    sender: mpsc::UnboundedSender<NotificationPayload>,
+}
+
+impl EventSubClient {
+    pub fn new(
+        helix: Arc<HelixClient<'static, reqwest::Client>>,
+        token: Arc<UserToken>,
+    ) -> (mpsc::UnboundedReceiver<NotificationPayload>, Self) {
+        let (sender, receiver) = mpsc::unbounded_channel::<NotificationPayload>();
+
+        let client = Self {
+            helix,
+            token,
+            session_id: Arc::new(Mutex::new(None)),
+            connected: Arc::new(AtomicBool::default()),
+            subscriptions: Arc::new(Mutex::new(HashMap::new())),
+            sender,
+        };
+
+        (receiver, client)
     }
 
-    pub async fn connect(self) {
-        let (mut stream, _) = connect_async(TWITCH_EVENTSUB_WS_URI).await.unwrap();
+    pub async fn connect(self: Arc<Self>) -> Result<(), Error> {
+        let (mut stream, _) = connect_async(TWITCH_EVENTSUB_WS_URI).await?;
+
+        self.set_connected(false);
+
+        let this = Arc::clone(&self);
 
         tokio::spawn(async move {
             while let Some(Ok(message)) = stream.next().await {
+                let this = Arc::clone(&this);
+
                 match message {
                     Message::Ping(data) => {
-                        stream.send(Message::Pong(data)).await;
+                        stream.send(Message::Pong(data)).await?;
                     }
-                    Message::Text(data) => {}
-                    Message::Close(frame) => {}
+                    Message::Text(data) => {
+                        if let Ok(msg) = serde_json::from_str(data.as_str()) {
+                            this.handle_message(msg).await?;
+                        }
+                    }
+                    Message::Close(_) => {
+                        self.set_connected(false);
+                    }
                     _ => (),
                 }
             }
+
+            self.set_connected(false);
+            Ok::<_, Error>(())
         });
+
+        Ok(())
+    }
+
+    // pub async fn disconnect(mut self) -> Result<(), Error> {
+    //     let frame = CloseFrame {
+    //         code: CloseCode::Normal,
+    //         reason: "Disconnected by client".into(),
+    //     };
+
+    //     // self.stream.close(Some(frame)).await?;
+    //     Ok(())
+    // }
+
+    async fn handle_message(self: Arc<Self>, msg: WebSocketMessage) -> Result<(), Error> {
+        use WebSocketMessage as Ws;
+
+        match msg {
+            Ws::Welcome(payload) => {
+                *self.session_id.lock().await = Some(payload.session.id);
+            }
+            Ws::Notification(payload) => {
+                self.sender.send(payload).unwrap();
+            }
+            Ws::Reconnect(_) => {
+                todo!()
+            }
+            Ws::Revocation(payload) => {
+                self.subscriptions
+                    .lock()
+                    .await
+                    .remove(&payload.subscription.kind.to_string());
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+
+    pub fn connected(&self) -> bool {
+        self.connected.load(Ordering::Relaxed)
+    }
+
+    pub fn set_connected(&self, value: bool) {
+        self.connected.store(value, Ordering::Relaxed);
     }
 
     pub async fn subscribe(
-        mut self,
-        event: String,
+        &self,
+        event: EventType,
         condition: serde_json::Value,
     ) -> Result<(), Error> {
+        let session_id = self.session_id.lock().await;
+
+        let Some(session_id) = session_id.as_ref() else {
+            return Err(Error::Generic(anyhow!("No EventSub connection")));
+        };
+
+        let version = if V2_EVENTS.contains(&event) { "1" } else { "2" };
+
         let body = json!({
             "type": event,
-            "version": "1",
+            "version": version,
             "condition": condition,
             "transport": {
                 "method": "websocket",
-                "session_id": self.session_id,
+                "session_id": session_id,
             }
         });
 
@@ -84,43 +254,49 @@ impl<'a> EventSubClient<'a> {
             .json()
             .await?;
 
-        self.subscriptions.insert(event, response.data.0.id.take());
+        self.subscriptions
+            .lock()
+            .await
+            .insert(event.to_string(), response.data.0.id.take());
 
         Ok(())
     }
 
     pub async fn subscribe_all(
-        self,
-        subscriptions: &[(&str, &serde_json::Value)],
+        &self,
+        subscriptions: &[(EventType, &serde_json::Value)],
     ) -> Result<(), Error> {
         let futures = subscriptions
             .iter()
-            .map(|&(event, condition)| self.clone().subscribe(event.into(), condition.clone()));
+            .map(|&(event, condition)| self.subscribe(event, condition.clone()));
 
-        try_join_all(futures).await?;
+        join_all(futures).await;
 
         Ok(())
     }
 
-    pub async fn unsubscribe(mut self, event: String) -> Result<(), Error> {
-        let id = self.subscriptions.remove(&event);
+    pub async fn unsubscribe(&self, event: String) -> Result<(), Error> {
+        let id = self.subscriptions.lock().await.remove(&event);
 
         if let Some(id) = id {
             self.helix
-                .delete_eventsub_subscription(id, self.token)
+                .delete_eventsub_subscription(id, &*self.token)
                 .await?;
         }
 
         Ok(())
     }
 
-    pub async fn unsubscribe_all(self) -> Result<(), Error> {
-        let futures = self
-            .subscriptions
-            .keys()
-            .map(|event| self.clone().unsubscribe(event.into()));
+    pub async fn unsubscribe_all(&self) -> Result<(), Error> {
+        let keys = {
+            let subscriptions = self.subscriptions.lock().await;
 
-        try_join_all(futures).await?;
+            subscriptions.keys().cloned().collect::<Vec<_>>()
+        };
+
+        let futures = keys.iter().map(|event| self.unsubscribe(event.into()));
+
+        join_all(futures).await;
 
         Ok(())
     }

--- a/src-tauri/src/eventsub/client.rs
+++ b/src-tauri/src/eventsub/client.rs
@@ -232,7 +232,7 @@ impl EventSubClient {
             return Err(Error::Generic(anyhow!("No EventSub connection")));
         };
 
-        let version = if V2_EVENTS.contains(&event) { "1" } else { "2" };
+        let version = if V2_EVENTS.contains(&event) { "2" } else { "1" };
 
         let body = json!({
             "type": event,

--- a/src-tauri/src/eventsub/client.rs
+++ b/src-tauri/src/eventsub/client.rs
@@ -1,0 +1,127 @@
+use std::collections::HashMap;
+
+use futures::future::try_join_all;
+use futures::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio::sync::mpsc;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use twitch_api::eventsub::EventSubSubscription;
+use twitch_api::twitch_oauth2::{TwitchToken, UserToken};
+use twitch_api::HelixClient;
+
+use crate::api::Response;
+use crate::error::Error;
+use crate::HTTP;
+
+const TWITCH_EVENTSUB_WS_URI: &str = "wss://eventsub.wss.twitch.tv/ws";
+
+#[derive(Clone)]
+pub struct EventSubClient<'a> {
+    helix: &'a HelixClient<'static, reqwest::Client>,
+    token: &'a UserToken,
+    session_id: Option<String>,
+    subscriptions: HashMap<String, String>,
+}
+
+impl<'a> EventSubClient<'a> {
+    pub fn new(
+        helix: &'a HelixClient<'static, reqwest::Client>,
+        token: &'a UserToken,
+    ) -> (mpsc::UnboundedReceiver<()>, Self) {
+        let (sender, receiver) = mpsc::unbounded_channel::<()>();
+
+        (
+            receiver,
+            Self {
+                helix,
+                token,
+                session_id: None,
+                subscriptions: HashMap::new(),
+            },
+        )
+    }
+
+    pub async fn connect(self) {
+        let (mut stream, _) = connect_async(TWITCH_EVENTSUB_WS_URI).await.unwrap();
+
+        tokio::spawn(async move {
+            while let Some(Ok(message)) = stream.next().await {
+                match message {
+                    Message::Ping(data) => {
+                        stream.send(Message::Pong(data)).await;
+                    }
+                    Message::Text(data) => {}
+                    Message::Close(frame) => {}
+                    _ => (),
+                }
+            }
+        });
+    }
+
+    pub async fn subscribe(
+        mut self,
+        event: String,
+        condition: serde_json::Value,
+    ) -> Result<(), Error> {
+        let body = json!({
+            "type": event,
+            "version": "1",
+            "condition": condition,
+            "transport": {
+                "method": "websocket",
+                "session_id": self.session_id,
+            }
+        });
+
+        let response: Response<(EventSubSubscription,)> = HTTP
+            .post("https://api.twitch.tv/helix/eventsub/subscriptions")
+            .bearer_auth(self.token.access_token.as_str())
+            .header("Client-Id", self.token.client_id().as_str())
+            .json(&body)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        self.subscriptions.insert(event, response.data.0.id.take());
+
+        Ok(())
+    }
+
+    pub async fn subscribe_all(
+        self,
+        subscriptions: &[(&str, &serde_json::Value)],
+    ) -> Result<(), Error> {
+        let futures = subscriptions
+            .iter()
+            .map(|&(event, condition)| self.clone().subscribe(event.into(), condition.clone()));
+
+        try_join_all(futures).await?;
+
+        Ok(())
+    }
+
+    pub async fn unsubscribe(mut self, event: String) -> Result<(), Error> {
+        let id = self.subscriptions.remove(&event);
+
+        if let Some(id) = id {
+            self.helix
+                .delete_eventsub_subscription(id, self.token)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn unsubscribe_all(self) -> Result<(), Error> {
+        let futures = self
+            .subscriptions
+            .keys()
+            .map(|event| self.clone().unsubscribe(event.into()));
+
+        try_join_all(futures).await?;
+
+        Ok(())
+    }
+}

--- a/src-tauri/src/eventsub/mod.rs
+++ b/src-tauri/src/eventsub/mod.rs
@@ -1,0 +1,21 @@
+pub mod client;
+
+pub use client::EventSubClient;
+use tauri::async_runtime::Mutex;
+use tauri::State;
+
+use crate::api::get_access_token;
+use crate::error::Error;
+use crate::AppState;
+
+#[tauri::command]
+pub async fn connect_eventsub(state: State<'_, Mutex<AppState>>) -> Result<(), Error> {
+    let state = state.lock().await;
+    let token = get_access_token(&state).await?;
+
+    let (mut incoming, client) = EventSubClient::new(&state.helix, token);
+
+    client.connect().await;
+
+    Ok(())
+}

--- a/src-tauri/src/eventsub/mod.rs
+++ b/src-tauri/src/eventsub/mod.rs
@@ -4,12 +4,9 @@ use std::sync::Arc;
 
 pub use client::EventSubClient;
 use client::NotificationPayload;
-use serde_json::json;
 use tauri::async_runtime::{self, Mutex};
 use tauri::ipc::Channel;
 use tauri::{AppHandle, Manager, State};
-use twitch_api::eventsub::EventType;
-use twitch_api::twitch_oauth2::TwitchToken;
 
 use crate::api::get_access_token;
 use crate::error::Error;
@@ -43,13 +40,6 @@ pub async fn connect_eventsub(
             let mut state = state.lock().await;
 
             state.eventsub = None;
-        } else {
-            client
-                .subscribe(
-                    EventType::UserUpdate,
-                    json!({ "user_id": client.token.user_id() }),
-                )
-                .await?;
         }
 
         Ok::<_, Error>(())

--- a/src-tauri/src/irc/client/event_loop.rs
+++ b/src-tauri/src/irc/client/event_loop.rs
@@ -70,6 +70,7 @@ impl ClientLoopWorker {
                     let new_connection = self.make_new_connection();
                     self.connections.push_back(new_connection);
                 }
+
                 return_sender.send(()).ok();
             }
             ClientLoopCommand::Join { channel_login } => self.join(channel_login),
@@ -211,6 +212,7 @@ impl ClientLoopWorker {
         match message {
             ConnectionIncomingMessage::IncomingMessage(message) => {
                 let is_whisper = matches!(*message, ServerMessage::Whisper(_));
+
                 if is_whisper {
                     match self.current_whisper_connection_id {
                         Some(current_whisper_connection_id) => {

--- a/src-tauri/src/irc/client/mod.rs
+++ b/src-tauri/src/irc/client/mod.rs
@@ -15,7 +15,7 @@ pub struct IrcClient {
 }
 
 impl IrcClient {
-    pub fn new(config: ClientConfig) -> (mpsc::UnboundedReceiver<ServerMessage>, IrcClient) {
+    pub fn new(config: ClientConfig) -> (mpsc::UnboundedReceiver<ServerMessage>, Self) {
         let config = Arc::new(config);
         let (client_loop_tx, client_loop_rx) = mpsc::unbounded_channel();
 
@@ -29,13 +29,14 @@ impl IrcClient {
             client_incoming_messages_tx,
         );
 
-        (client_incoming_messages_rx, IrcClient { client_loop_tx })
+        (client_incoming_messages_rx, Self { client_loop_tx })
     }
 }
 
 impl IrcClient {
     pub async fn connect(&self) {
         let (return_tx, return_rx) = oneshot::channel();
+
         self.client_loop_tx
             .send(ClientLoopCommand::Connect {
                 return_sender: return_tx,

--- a/src-tauri/src/irc/mod.rs
+++ b/src-tauri/src/irc/mod.rs
@@ -22,7 +22,7 @@ use crate::error::Error as AppError;
 use crate::AppState;
 
 #[tauri::command]
-pub async fn connect(
+pub async fn connect_irc(
     state: State<'_, Mutex<AppState>>,
     channel: Channel<ServerMessage>,
 ) -> Result<(), AppError> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::sync::LazyLock;
 
+use eventsub::EventSubClient;
 use irc::IrcClient;
 use reqwest::header::HeaderMap;
 use tauri::async_runtime::{self, Mutex};
@@ -14,6 +15,7 @@ use twitch_api::HelixClient;
 mod api;
 mod emotes;
 mod error;
+mod eventsub;
 mod irc;
 mod providers;
 
@@ -32,16 +34,18 @@ pub static HTTP: LazyLock<reqwest::Client> = LazyLock::new(|| {
 
 pub struct AppState {
     helix: HelixClient<'static, reqwest::Client>,
-    irc: Option<IrcClient>,
     token: Option<UserToken>,
+    irc: Option<IrcClient>,
+    eventsub: Option<EventSubClient<'static>>,
 }
 
 impl Default for AppState {
     fn default() -> Self {
         Self {
             helix: HelixClient::new(),
-            irc: None,
             token: None,
+            irc: None,
+            eventsub: None,
         }
     }
 }
@@ -106,7 +110,6 @@ pub fn run() {
 
 fn get_handler() -> impl Fn(Invoke) -> bool {
     tauri::generate_handler![
-        irc::connect,
         api::set_access_token,
         api::channels::get_stream,
         api::channels::get_followed_channels,
@@ -119,6 +122,7 @@ fn get_handler() -> impl Fn(Invoke) -> bool {
         api::users::get_user_from_login,
         api::users::get_user_emotes,
         api::users::get_moderated_channels,
+        irc::connect,
         emotes::fetch_global_emotes,
     ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(duration_constructors, try_blocks)]
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use eventsub::EventSubClient;
 use irc::IrcClient;
@@ -36,7 +36,7 @@ pub struct AppState {
     helix: HelixClient<'static, reqwest::Client>,
     token: Option<UserToken>,
     irc: Option<IrcClient>,
-    eventsub: Option<EventSubClient<'static>>,
+    eventsub: Option<Arc<EventSubClient>>,
 }
 
 impl Default for AppState {
@@ -122,7 +122,8 @@ fn get_handler() -> impl Fn(Invoke) -> bool {
         api::users::get_user_from_login,
         api::users::get_user_emotes,
         api::users::get_moderated_channels,
-        irc::connect,
+        irc::connect_irc,
         emotes::fetch_global_emotes,
+        eventsub::connect_eventsub,
     ]
 }

--- a/src/lib/twitch/index.ts
+++ b/src/lib/twitch/index.ts
@@ -57,8 +57,6 @@ export const SCOPES = [
 
 export async function connect() {
 	const channel = new Channel<IrcMessage>(async (message) => {
-		console.log(message);
-
 		const handler = handlers.get(message.type);
 		await handler?.handle(message);
 	});

--- a/src/lib/twitch/index.ts
+++ b/src/lib/twitch/index.ts
@@ -1,3 +1,7 @@
+import { Channel, invoke } from "@tauri-apps/api/core";
+import { handlers } from "$lib/handlers";
+import type { IrcMessage } from "./irc";
+
 export const SCOPES = [
 	// Channel
 	"channel:edit:commercial",
@@ -50,3 +54,15 @@ export const SCOPES = [
 	"clips:edit",
 	"whispers:read",
 ];
+
+export async function connect() {
+	const channel = new Channel<IrcMessage>(async (message) => {
+		console.log(message);
+
+		const handler = handlers.get(message.type);
+		await handler?.handle(message);
+	});
+
+	await invoke("connect_irc", { channel });
+	await invoke("connect_eventsub", { channel });
+}

--- a/src/lib/twitch/irc.ts
+++ b/src/lib/twitch/irc.ts
@@ -1,6 +1,3 @@
-import { Channel, invoke } from "@tauri-apps/api/core";
-import { handlers } from "$lib/handlers";
-
 export interface JoinMessage {
 	type: "join";
 	channel_login: string;
@@ -192,12 +189,3 @@ export type IrcMessage =
 export type IrcMessageMap = {
 	[K in IrcMessage["type"]]: Extract<IrcMessage, { type: K }>;
 };
-
-export async function connect() {
-	const channel = new Channel<IrcMessage>(async (message) => {
-		const handler = handlers.get(message.type);
-		await handler?.handle(message);
-	});
-
-	await invoke("connect", { channel });
-}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,7 +8,7 @@
 	import Sidebar from "$lib/components/Sidebar.svelte";
 	import { settings } from "$lib/settings";
 	import { app } from "$lib/state.svelte";
-	import { connect } from "$lib/twitch/irc";
+	import { connect } from "$lib/twitch";
 
 	const { children } = $props();
 

--- a/src/routes/[channel]/+page.svelte
+++ b/src/routes/[channel]/+page.svelte
@@ -12,7 +12,7 @@
 
 	const { data } = $props();
 
-	let unlisten: UnlistenFn;
+	let unlisten: UnlistenFn | undefined;
 
 	onMount(async () => {
 		unlisten = await listen<IrcMessage[]>(
@@ -26,7 +26,7 @@
 		);
 	});
 
-	onDestroy(() => unlisten());
+	onDestroy(() => unlisten?.());
 
 	$effect(() => {
 		join();


### PR DESCRIPTION
Turns out the hybrid approach was best after all. IRC will probably get removed at some point if/when Twitch decides to send first message and returning chatter information with `channel.chat.message` events, but for now, I'm just going to deal with both.

- https://twitch.uservoice.com/forums/310213-developers/suggestions/43371027-allow-getting-realtime-updates-on-polls-prediction
- https://twitch.uservoice.com/forums/310213-developers/suggestions/48181199-first-time-chatters

Closes #24 
Reopens #8 