### PR TITLE
feat: handle `channel.moderate`/`CLEARCHAT`/`NOTICE` events

### DIFF
--- a/src-tauri/src/api/users.rs
+++ b/src-tauri/src/api/users.rs
@@ -166,7 +166,7 @@ pub async fn get_moderated_channels(
 
     let ids = channels
         .into_iter()
-        .map(|ch| ch.broadcaster_id.to_string())
+        .map(|ch| ch.broadcaster_login.to_string())
         .collect();
 
     Ok(ids)

--- a/src-tauri/src/eventsub/client.rs
+++ b/src-tauri/src/eventsub/client.rs
@@ -50,7 +50,7 @@ pub struct MessageMetadata {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Subscription {
     pub id: String,
-    #[serde(rename(serialize = "type"))]
+    #[serde(rename = "type")]
     kind: EventType,
 }
 

--- a/src-tauri/src/irc/message/commands.rs
+++ b/src-tauri/src/irc/message/commands.rs
@@ -208,6 +208,9 @@ pub struct NoticeMessage {
     pub channel_login: Option<String>,
     pub message_text: String,
     pub message_id: Option<String>,
+    pub deleted: bool,
+    pub is_recent: bool,
+    pub recent_timestamp: Option<u64>,
     pub source: IrcMessage,
 }
 
@@ -227,6 +230,13 @@ impl TryFrom<IrcMessage> for NoticeMessage {
             message_id: source
                 .try_get_optional_nonempty_tag_value("msg-id")?
                 .map(|s| s.to_owned()),
+            deleted: source
+                .try_get_optional_bool("rm-deleted")?
+                .unwrap_or_default(),
+            is_recent: source
+                .try_get_optional_bool("historical")?
+                .unwrap_or_default(),
+            recent_timestamp: source.try_get_timestamp("rm-received-ts").ok(),
             source,
         })
     }

--- a/src-tauri/src/irc/message/commands.rs
+++ b/src-tauri/src/irc/message/commands.rs
@@ -14,6 +14,7 @@ pub struct ClearChatMessage {
     pub channel_login: String,
     pub channel_id: String,
     pub action: ClearChatAction,
+    pub is_recent: bool,
     pub server_timestamp: u64,
     pub source: IrcMessage,
 }
@@ -76,6 +77,9 @@ impl TryFrom<IrcMessage> for ClearChatMessage {
             channel_login: source.try_get_channel_login()?.to_owned(),
             channel_id: source.try_get_nonempty_tag_value("room-id")?.to_owned(),
             action,
+            is_recent: source
+                .try_get_optional_bool("historical")?
+                .unwrap_or_default(),
             server_timestamp: source.try_get_timestamp("tmi-sent-ts")?,
             source,
         })
@@ -376,7 +380,9 @@ impl TryFrom<IrcMessage> for PrivmsgMessage {
             deleted: source
                 .try_get_optional_bool("rm-deleted")?
                 .unwrap_or_default(),
-            is_recent: source.tags.0.contains_key("rm-received-ts"),
+            is_recent: source
+                .try_get_optional_bool("historical")?
+                .unwrap_or_default(),
             source,
         })
     }
@@ -712,7 +718,9 @@ impl TryFrom<IrcMessage> for UserNoticeMessage {
             deleted: source
                 .try_get_optional_bool("rm-deleted")?
                 .unwrap_or_default(),
-            is_recent: source.tags.0.contains_key("rm-received-ts"),
+            is_recent: source
+                .try_get_optional_bool("historical")?
+                .unwrap_or_default(),
             server_timestamp: source.try_get_timestamp("tmi-sent-ts")?.to_owned(),
             source,
         })

--- a/src/lib/channel.svelte.ts
+++ b/src/lib/channel.svelte.ts
@@ -118,7 +118,7 @@ export class Channel {
 		return this;
 	}
 
-	public addMessage(message: UserMessage) {
+	public addMessage(message: Message) {
 		if (this.messages.some((m) => m.id === message.id)) {
 			return;
 		}

--- a/src/lib/channel.svelte.ts
+++ b/src/lib/channel.svelte.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { SvelteMap } from "svelte/reactivity";
 import { replyTarget } from "./components/Input.svelte";
-import type { Message, UserMessage } from "./message";
+import type { Message } from "./message";
 import { settings } from "./settings";
 import type { JoinedChannel } from "./tauri";
 import type { Badge, BadgeSet, Stream } from "./twitch/api";
@@ -134,6 +134,8 @@ export class Channel {
 		} else {
 			this.messages.push(message);
 		}
+
+		return this;
 	}
 
 	public async send(message: string) {

--- a/src/lib/components/Chat.svelte
+++ b/src/lib/components/Chat.svelte
@@ -65,29 +65,28 @@
 	>
 		{#snippet children(message: Message, i)}
 			{#if !message.isUser()}
+				{/* @ts-expect-error */ null}
 				<SystemMessage {message} />
+			{:else if message.event}
+				<Notification {message} />
 			{:else}
-				{@const next = app.active.messages.at(i + 1)}
+				<UserMessage {message} />
+			{/if}
 
-				{#if message.event}
-					<Notification {message} />
-				{:else}
-					<UserMessage {message} />
-				{/if}
+			{@const next = app.active.messages.at(i + 1)}
 
-				{#if message.isRecent && (!next || !next.isUser() || !next.isRecent)}
-					<div class="text-twitch relative px-3.5">
-						<Separator.Root
-							class="my-4 h-px w-full rounded-full bg-current"
-						/>
+			{#if message.isRecent && !next?.isRecent}
+				<div class="text-twitch relative px-3.5">
+					<Separator.Root
+						class="my-4 h-px w-full rounded-full bg-current"
+					/>
 
-						<div
-							class="bg-background absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 px-2 text-xs font-semibold uppercase"
-						>
-							Live messages
-						</div>
+					<div
+						class="bg-background absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 px-2 text-xs font-semibold uppercase"
+					>
+						Live messages
 					</div>
-				{/if}
+				</div>
 			{/if}
 		{/snippet}
 	</VList>

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -17,16 +17,19 @@ export default defineHandler({
 
 		switch (data.action) {
 			case "ban": {
-				let target = app.active.viewers.get(data.ban.user_login);
-				target ??= Viewer.from(data.ban);
+				const target = Viewer.from(data.ban);
 
 				app.active.addMessage(message.ban(target, moderator));
 				break;
 			}
 
+			case "clear": {
+				app.active.addMessage(message.clear(moderator));
+				break;
+			}
+
 			case "timeout": {
-				let target = app.active.viewers.get(data.timeout.user_login);
-				target ??= Viewer.from(data.timeout);
+				const target = Viewer.from(data.timeout);
 
 				const expiration = new Date(data.timeout.expires_at);
 				const duration =
@@ -39,6 +42,8 @@ export default defineHandler({
 						moderator,
 					),
 				);
+
+				break;
 			}
 		}
 	},

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -16,6 +16,60 @@ export default defineHandler({
 		});
 
 		switch (data.action) {
+			case "emoteonly":
+			case "emoteonlyoff":
+			case "subscribers":
+			case "subscribersoff":
+			case "uniquechat":
+			case "uniquechatoff": {
+				const mode = data.action.startsWith("emote")
+					? "emote-only"
+					: data.action.startsWith("unique")
+						? "unique-mode"
+						: "subscriber-only";
+
+				app.active.addMessage(
+					message.mode(
+						mode,
+						data.action.includes("off"),
+						Number.NaN,
+						moderator,
+					),
+				);
+
+				break;
+			}
+
+			case "followers":
+			case "followersoff": {
+				app.active.addMessage(
+					message.mode(
+						"follower-only",
+						data.action.includes("off"),
+						data.followers
+							? data.followers.follow_duration_minutes * 60
+							: Number.NaN,
+						moderator,
+					),
+				);
+
+				break;
+			}
+
+			case "slow":
+			case "slowoff": {
+				app.active.addMessage(
+					message.mode(
+						"slow",
+						!data.slow,
+						data.slow?.wait_time_seconds ?? Number.NaN,
+						moderator,
+					),
+				);
+
+				break;
+			}
+
 			case "ban": {
 				const target = Viewer.from(data.ban);
 

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -75,6 +75,17 @@ export default defineHandler({
 				break;
 			}
 
+			case "add_blocked_term":
+			case "add_permitted_term":
+			case "remove_blocked_term":
+			case "remove_permitted_term": {
+				app.active.addMessage(
+					message.term(data.automod_terms, moderator),
+				);
+
+				break;
+			}
+
 			case "warn": {
 				const target = Viewer.from(data.warn);
 				app.active.addMessage(message.warn(target, moderator));
@@ -102,8 +113,8 @@ export default defineHandler({
 
 			case "untimeout": {
 				const target = Viewer.from(data.untimeout);
-
 				app.active.addMessage(message.untimeout(target, moderator));
+
 				break;
 			}
 

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -102,7 +102,9 @@ export default defineHandler({
 
 			case "warn": {
 				const target = Viewer.from(data.warn);
-				app.active.addMessage(message.warn(target, moderator));
+				app.active.addMessage(
+					message.warn(data.warn, target, moderator),
+				);
 
 				break;
 			}
@@ -117,6 +119,7 @@ export default defineHandler({
 				app.active.addMessage(
 					message.timeout(
 						Math.ceil(duration / 1000),
+						data.timeout.reason,
 						target,
 						moderator,
 					),
@@ -138,7 +141,12 @@ export default defineHandler({
 				const target = Viewer.from(isBan ? data.ban : data.unban);
 
 				app.active.addMessage(
-					message.banStatus(isBan, target, moderator),
+					message.banStatus(
+						isBan,
+						isBan ? data.ban.reason : null,
+						target,
+						moderator,
+					),
 				);
 
 				break;

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -75,14 +75,9 @@ export default defineHandler({
 				break;
 			}
 
-			case "ban":
-			case "unban": {
-				const isBan = data.action === "ban";
-				const target = Viewer.from(isBan ? data.ban : data.unban);
-
-				app.active.addMessage(
-					message.banStatus(!isBan, target, moderator),
-				);
+			case "warn": {
+				const target = Viewer.from(data.warn);
+				app.active.addMessage(message.warn(target, moderator));
 
 				break;
 			}
@@ -109,6 +104,18 @@ export default defineHandler({
 				const target = Viewer.from(data.untimeout);
 
 				app.active.addMessage(message.untimeout(target, moderator));
+				break;
+			}
+
+			case "ban":
+			case "unban": {
+				const isBan = data.action === "ban";
+				const target = Viewer.from(isBan ? data.ban : data.unban);
+
+				app.active.addMessage(
+					message.banStatus(!isBan, target, moderator),
+				);
+
 				break;
 			}
 

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -70,10 +70,15 @@ export default defineHandler({
 				break;
 			}
 
-			case "ban": {
-				const target = Viewer.from(data.ban);
+			case "ban":
+			case "unban": {
+				const isBan = data.action === "ban";
+				const target = Viewer.from(isBan ? data.ban : data.unban);
 
-				app.active.addMessage(message.ban(target, moderator));
+				app.active.addMessage(
+					message.banStatus(!isBan, target, moderator),
+				);
+
 				break;
 			}
 
@@ -97,6 +102,13 @@ export default defineHandler({
 					),
 				);
 
+				break;
+			}
+
+			case "untimeout": {
+				const target = Viewer.from(data.untimeout);
+
+				app.active.addMessage(message.untimeout(target, moderator));
 				break;
 			}
 		}

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -21,6 +21,24 @@ export default defineHandler({
 				target ??= Viewer.from(data.ban);
 
 				app.active.addMessage(message.ban(target, moderator));
+				break;
+			}
+
+			case "timeout": {
+				let target = app.active.viewers.get(data.timeout.user_login);
+				target ??= Viewer.from(data.timeout);
+
+				const expiration = new Date(data.timeout.expires_at);
+				const duration =
+					expiration.getTime() - message.timestamp.getTime();
+
+				app.active.addMessage(
+					message.timeout(
+						Math.ceil(duration / 1000),
+						target,
+						moderator,
+					),
+				);
 			}
 		}
 	},

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -16,6 +16,20 @@ export default defineHandler({
 		});
 
 		switch (data.action) {
+			case "approve_unban_request":
+			case "deny_unban_request": {
+				const target = Viewer.from(data.unban_request);
+				app.active.addMessage(
+					message.unbanRequest(
+						data.unban_request.is_approved,
+						target,
+						moderator,
+					),
+				);
+
+				break;
+			}
+
 			case "emoteonly":
 			case "emoteonlyoff":
 			case "subscribers":

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -70,6 +70,11 @@ export default defineHandler({
 				break;
 			}
 
+			case "clear": {
+				app.active.addMessage(message.clear(moderator));
+				break;
+			}
+
 			case "ban":
 			case "unban": {
 				const isBan = data.action === "ban";
@@ -79,11 +84,6 @@ export default defineHandler({
 					message.banStatus(!isBan, target, moderator),
 				);
 
-				break;
-			}
-
-			case "clear": {
-				app.active.addMessage(message.clear(moderator));
 				break;
 			}
 
@@ -109,6 +109,30 @@ export default defineHandler({
 				const target = Viewer.from(data.untimeout);
 
 				app.active.addMessage(message.untimeout(target, moderator));
+				break;
+			}
+
+			case "mod":
+			case "unmod": {
+				const added = data.action === "mod";
+				const target = Viewer.from(added ? data.mod : data.unmod);
+
+				app.active.addMessage(
+					message.roleStatus("moderator", !added, target, moderator),
+				);
+
+				break;
+			}
+
+			case "vip":
+			case "unvip": {
+				const added = data.action === "vip";
+				const target = Viewer.from(added ? data.vip : data.unvip);
+
+				app.active.addMessage(
+					message.roleStatus("VIP", !added, target, moderator),
+				);
+
 				break;
 			}
 		}

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -18,13 +18,8 @@ export default defineHandler({
 		switch (data.action) {
 			case "approve_unban_request":
 			case "deny_unban_request": {
-				const target = Viewer.from(data.unban_request);
 				app.active.addMessage(
-					message.unbanRequest(
-						data.unban_request.is_approved,
-						target,
-						moderator,
-					),
+					message.unbanRequest(data.unban_request, moderator),
 				);
 
 				break;
@@ -101,11 +96,7 @@ export default defineHandler({
 			}
 
 			case "warn": {
-				const target = Viewer.from(data.warn);
-				app.active.addMessage(
-					message.warn(data.warn, target, moderator),
-				);
-
+				app.active.addMessage(message.warn(data.warn, moderator));
 				break;
 			}
 

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -1,8 +1,27 @@
+import { SystemMessage } from "$lib/message";
+import { app } from "$lib/state.svelte";
+import { Viewer } from "$lib/viewer.svelte";
 import { defineHandler } from "../helper";
 
 export default defineHandler({
 	name: "channel.moderate",
 	handle(data) {
-		//
+		const message = new SystemMessage();
+
+		let moderator = app.active.viewers.get(data.moderator_user_login);
+		moderator ??= new Viewer({
+			id: data.moderator_user_id,
+			username: data.moderator_user_login,
+			displayName: data.moderator_user_name,
+		});
+
+		switch (data.action) {
+			case "ban": {
+				let target = app.active.viewers.get(data.ban.user_login);
+				target ??= Viewer.from(data.ban);
+
+				app.active.addMessage(message.ban(target, moderator));
+			}
+		}
 	},
 });

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -45,7 +45,7 @@ export default defineHandler({
 				app.active.addMessage(
 					message.mode(
 						mode,
-						data.action.includes("off"),
+						!data.action.includes("off"),
 						Number.NaN,
 						moderator,
 					),
@@ -59,7 +59,7 @@ export default defineHandler({
 				app.active.addMessage(
 					message.mode(
 						"follower-only",
-						data.action.includes("off"),
+						!data.action.includes("off"),
 						data.followers
 							? data.followers.follow_duration_minutes * 60
 							: Number.NaN,
@@ -75,7 +75,7 @@ export default defineHandler({
 				app.active.addMessage(
 					message.mode(
 						"slow",
-						!data.slow,
+						data.slow !== null,
 						data.slow?.wait_time_seconds ?? Number.NaN,
 						moderator,
 					),
@@ -138,7 +138,7 @@ export default defineHandler({
 				const target = Viewer.from(isBan ? data.ban : data.unban);
 
 				app.active.addMessage(
-					message.banStatus(!isBan, target, moderator),
+					message.banStatus(isBan, target, moderator),
 				);
 
 				break;
@@ -150,7 +150,7 @@ export default defineHandler({
 				const target = Viewer.from(added ? data.mod : data.unmod);
 
 				app.active.addMessage(
-					message.roleStatus("moderator", !added, target, moderator),
+					message.roleStatus("moderator", added, target, moderator),
 				);
 
 				break;
@@ -162,7 +162,7 @@ export default defineHandler({
 				const target = Viewer.from(added ? data.vip : data.unvip);
 
 				app.active.addMessage(
-					message.roleStatus("VIP", !added, target, moderator),
+					message.roleStatus("VIP", added, target, moderator),
 				);
 
 				break;

--- a/src/lib/handlers/eventsub/channel-moderate.ts
+++ b/src/lib/handlers/eventsub/channel-moderate.ts
@@ -1,0 +1,8 @@
+import { defineHandler } from "../helper";
+
+export default defineHandler({
+	name: "channel.moderate",
+	handle(data) {
+		//
+	},
+});

--- a/src/lib/handlers/helper.ts
+++ b/src/lib/handlers/helper.ts
@@ -1,12 +1,19 @@
+import type { SubscriptionEventMap } from "$lib/twitch/eventsub";
 import type { IrcMessageMap } from "$lib/twitch/irc";
 
-export interface Handler<K extends keyof IrcMessageMap> {
+type HandlerKey = keyof IrcMessageMap | keyof SubscriptionEventMap;
+
+type HandlerData<K> = K extends keyof IrcMessageMap
+	? IrcMessageMap[K]
+	: K extends keyof SubscriptionEventMap
+		? SubscriptionEventMap[K]
+		: never;
+
+export interface Handler<K extends HandlerKey = HandlerKey> {
 	name: K;
-	handle: (data: IrcMessageMap[K]) => Promise<void> | void;
+	handle: (data: HandlerData<K>) => Promise<void> | void;
 }
 
-export function defineHandler<K extends keyof IrcMessageMap>(
-	handler: Handler<K>,
-) {
+export function defineHandler<K extends HandlerKey>(handler: Handler<K>) {
 	return handler;
 }

--- a/src/lib/handlers/index.ts
+++ b/src/lib/handlers/index.ts
@@ -7,6 +7,7 @@ import clearchat from "./irc/clearchat";
 import clearmsg from "./irc/clearmsg";
 import privmsg from "./irc/privmsg";
 import usernotice from "./irc/usernotice";
+import notice from "./irc/notice";
 import part from "./irc/part";
 //
 import channelModerate from "./eventsub/channel-moderate";
@@ -22,6 +23,7 @@ register(clearchat);
 register(clearmsg);
 register(privmsg);
 register(usernotice);
+register(notice);
 register(part);
 
 register(channelModerate);

--- a/src/lib/handlers/index.ts
+++ b/src/lib/handlers/index.ts
@@ -1,15 +1,16 @@
 /* eslint-disable perfectionist/sort-imports */
 
-import type { IrcMessageMap } from "$lib/twitch/irc";
 import type { Handler } from "./helper";
 //
-import join from "./join";
-import clearmsg from "./clearmsg";
-import privmsg from "./privmsg";
-import usernotice from "./usernotice";
-import part from "./part";
+import join from "./irc/join";
+import clearmsg from "./irc/clearmsg";
+import privmsg from "./irc/privmsg";
+import usernotice from "./irc/usernotice";
+import part from "./irc/part";
+//
+import channelModerate from "./eventsub/channel-moderate";
 
-export const handlers = new Map<string, Handler<keyof IrcMessageMap>>();
+export const handlers = new Map<string, Handler>();
 
 function register(handler: Handler<any>) {
 	handlers.set(handler.name, handler);
@@ -20,3 +21,5 @@ register(clearmsg);
 register(privmsg);
 register(usernotice);
 register(part);
+
+register(channelModerate);

--- a/src/lib/handlers/index.ts
+++ b/src/lib/handlers/index.ts
@@ -3,6 +3,7 @@
 import type { Handler } from "./helper";
 //
 import join from "./irc/join";
+import clearchat from "./irc/clearchat";
 import clearmsg from "./irc/clearmsg";
 import privmsg from "./irc/privmsg";
 import usernotice from "./irc/usernotice";
@@ -17,6 +18,7 @@ function register(handler: Handler<any>) {
 }
 
 register(join);
+register(clearchat);
 register(clearmsg);
 register(privmsg);
 register(usernotice);

--- a/src/lib/handlers/irc/clearchat.ts
+++ b/src/lib/handlers/irc/clearchat.ts
@@ -15,7 +15,7 @@ export default defineHandler({
 		const message = new SystemMessage(data);
 
 		if (data.action.type === "clear") {
-			// todo
+			app.active.addMessage(message.clear());
 			return;
 		}
 

--- a/src/lib/handlers/irc/clearchat.ts
+++ b/src/lib/handlers/irc/clearchat.ts
@@ -28,7 +28,7 @@ export default defineHandler({
 		});
 
 		if (data.action.type === "ban") {
-			app.active.addMessage(message.ban(target));
+			app.active.addMessage(message.banStatus(target));
 		} else {
 			app.active.addMessage(
 				message.timeout(data.action.duration.secs, target),

--- a/src/lib/handlers/irc/clearchat.ts
+++ b/src/lib/handlers/irc/clearchat.ts
@@ -1,0 +1,34 @@
+import { SystemMessage } from "$lib/message";
+import { app } from "$lib/state.svelte";
+import { Viewer } from "$lib/viewer.svelte";
+import { defineHandler } from "../helper";
+
+export default defineHandler({
+	name: "clearchat",
+	handle(data) {
+		// Return early if the message isn't recent and the user is a moderator
+		// in the channel to prevent showing two different messages.
+		if (!data.is_recent && app.user?.moderating.has(data.channel_id)) {
+			return;
+		}
+
+		const message = new SystemMessage(data);
+
+		if (data.action.type === "clear") {
+			// todo
+			return;
+		}
+
+		let target = app.active.viewers.get(data.action.user_login);
+
+		target ??= new Viewer({
+			id: data.action.user_id,
+			username: data.action.user_login,
+			displayName: data.action.user_login,
+		});
+
+		if (data.action.type === "ban") {
+			app.active.addMessage(message.ban(target));
+		}
+	},
+});

--- a/src/lib/handlers/irc/clearchat.ts
+++ b/src/lib/handlers/irc/clearchat.ts
@@ -8,7 +8,7 @@ export default defineHandler({
 	handle(data) {
 		// Return early if the message isn't recent and the user is a moderator
 		// in the channel to prevent showing two different messages.
-		if (!data.is_recent && app.user?.moderating.has(data.channel_id)) {
+		if (!data.is_recent && app.user?.moderating.has(data.channel_login)) {
 			return;
 		}
 

--- a/src/lib/handlers/irc/clearchat.ts
+++ b/src/lib/handlers/irc/clearchat.ts
@@ -28,10 +28,10 @@ export default defineHandler({
 		});
 
 		if (data.action.type === "ban") {
-			app.active.addMessage(message.banStatus(false, target));
+			app.active.addMessage(message.banStatus(false, null, target));
 		} else {
 			app.active.addMessage(
-				message.timeout(data.action.duration.secs, target),
+				message.timeout(data.action.duration.secs, null, target),
 			);
 		}
 	},

--- a/src/lib/handlers/irc/clearchat.ts
+++ b/src/lib/handlers/irc/clearchat.ts
@@ -29,6 +29,10 @@ export default defineHandler({
 
 		if (data.action.type === "ban") {
 			app.active.addMessage(message.ban(target));
+		} else {
+			app.active.addMessage(
+				message.timeout(data.action.duration.secs, target),
+			);
 		}
 	},
 });

--- a/src/lib/handlers/irc/clearchat.ts
+++ b/src/lib/handlers/irc/clearchat.ts
@@ -28,7 +28,7 @@ export default defineHandler({
 		});
 
 		if (data.action.type === "ban") {
-			app.active.addMessage(message.banStatus(target));
+			app.active.addMessage(message.banStatus(false, target));
 		} else {
 			app.active.addMessage(
 				message.timeout(data.action.duration.secs, target),

--- a/src/lib/handlers/irc/clearmsg.ts
+++ b/src/lib/handlers/irc/clearmsg.ts
@@ -1,6 +1,6 @@
 import type { UserMessage } from "$lib/message";
 import { app } from "$lib/state.svelte";
-import { defineHandler } from "./helper";
+import { defineHandler } from "../helper";
 
 export default defineHandler({
 	name: "clearmsg",

--- a/src/lib/handlers/irc/join.ts
+++ b/src/lib/handlers/irc/join.ts
@@ -1,6 +1,6 @@
 import { SystemMessage } from "$lib/message";
 import { app } from "$lib/state.svelte";
-import { defineHandler } from "./helper";
+import { defineHandler } from "../helper";
 
 export default defineHandler({
 	name: "join",

--- a/src/lib/handlers/irc/notice.ts
+++ b/src/lib/handlers/irc/notice.ts
@@ -1,0 +1,38 @@
+import { SystemMessage } from "$lib/message";
+import { app } from "$lib/state.svelte";
+import { defineHandler } from "../helper";
+
+export default defineHandler({
+	name: "notice",
+	async handle(data) {
+		if (!data.is_recent && app.user?.moderating.has(data.channel_login)) {
+			return;
+		}
+
+		const message = new SystemMessage({
+			is_recent: data.is_recent,
+			server_timestamp: data.recent_timestamp ?? Date.now(),
+		});
+
+		switch (data.message_id) {
+			case "emote_only_on":
+			case "emote_only_off":
+			case "followers_on":
+			case "followers_on_zero":
+			case "followers_off":
+			case "r9k_on":
+			case "r9k_off":
+			case "slow_on":
+			case "slow_off":
+			case "subs_on":
+			case "subs_off": {
+				const text = data.message_text
+					.replace("This room", "The chat")
+					.replace("s-only", "-only");
+
+				app.active.addMessage(message.setText(text));
+				break;
+			}
+		}
+	},
+});

--- a/src/lib/handlers/irc/part.ts
+++ b/src/lib/handlers/irc/part.ts
@@ -1,5 +1,5 @@
 import { app } from "$lib/state.svelte";
-import { defineHandler } from "./helper";
+import { defineHandler } from "../helper";
 
 export default defineHandler({
 	name: "part",

--- a/src/lib/handlers/irc/privmsg.ts
+++ b/src/lib/handlers/irc/privmsg.ts
@@ -1,6 +1,6 @@
 import { UserMessage } from "$lib/message";
 import { app } from "$lib/state.svelte";
-import { defineHandler } from "./helper";
+import { defineHandler } from "../helper";
 
 export default defineHandler({
 	name: "privmsg",

--- a/src/lib/handlers/irc/usernotice.ts
+++ b/src/lib/handlers/irc/usernotice.ts
@@ -1,6 +1,6 @@
 import { UserMessage } from "$lib/message";
 import { app } from "$lib/state.svelte";
-import { defineHandler } from "./helper";
+import { defineHandler } from "../helper";
 
 export default defineHandler({
 	name: "usernotice",

--- a/src/lib/message/message.ts
+++ b/src/lib/message/message.ts
@@ -11,44 +11,28 @@ export abstract class Message {
 	 * The timestamp at which the message was sent at. For a human-readable
 	 * format, use {@linkcode formattedTime}.
 	 */
-	public readonly timestamp = new Date();
+	public readonly timestamp: Date;
 
 	public constructor(
 		readonly data: MessageData,
 		system = false,
 	) {
 		this.#system = system;
-
-		if (this.isUser()) {
-			this.timestamp = new Date(
-				(this.data as BaseUserMessage).server_timestamp,
-			);
-		}
+		this.timestamp = new Date(this.data.server_timestamp);
 	}
 
-	public get id(): string {
-		if (this.isUser()) {
-			return this.data.message_id;
-		}
+	public abstract get id(): string;
+	public abstract get text(): string;
 
-		return (this.data as SystemMessageData).id;
+	/**
+	 * Whether the message was retreived by the `recent-messages` API.
+	 */
+	public get isRecent() {
+		return this.data.is_recent;
 	}
 
-	public get formattedTime(): string {
+	public get formattedTime() {
 		return formatTime(this.timestamp);
-	}
-
-	public get text(): string {
-		if (this.isUser()) {
-			// message_text should only be possibly null if it's a USERNOTICE,
-			// in which case we can assume system_message is present
-			return (
-				this.data.message_text ??
-				(this.data as UserNoticeMessage).system_message
-			);
-		}
-
-		return (this.data as SystemMessageData).text;
 	}
 
 	public isUser(): this is UserMessage {

--- a/src/lib/message/system-message.ts
+++ b/src/lib/message/system-message.ts
@@ -147,6 +147,16 @@ export class SystemMessage extends Message {
 		return this;
 	}
 
+	/**
+	 * Sets the text of the system message when a user is warned.
+	 *
+	 * `{moderator} warned {user}`
+	 */
+	public warn(user: Viewer, moderator: Viewer) {
+		this.#text = `${this.#name(moderator)} warned ${this.#name(user)}`;
+		return this;
+	}
+
 	#name(user: PartialUser) {
 		return html`
 			<span class="font-semibold" style="color: ${user.color};">

--- a/src/lib/message/system-message.ts
+++ b/src/lib/message/system-message.ts
@@ -21,6 +21,7 @@ const html = String.raw;
  * information to the user.
  */
 export class SystemMessage extends Message {
+	#id = crypto.randomUUID();
 	#text = "";
 
 	public constructor(data: Partial<SystemMessageData> = {}) {
@@ -42,7 +43,7 @@ export class SystemMessage extends Message {
 	}
 
 	public override get id() {
-		return crypto.randomUUID();
+		return this.#id;
 	}
 
 	public override get text() {

--- a/src/lib/message/system-message.ts
+++ b/src/lib/message/system-message.ts
@@ -160,6 +160,19 @@ export class SystemMessage extends Message {
 	}
 
 	/**
+	 * Sets the text of the system message when a user's unban request is
+	 * approved or denied.
+	 *
+	 * `{moderator} approved/denied {user}'s unban request`
+	 */
+	public unbanRequest(approved: boolean, user: Viewer, moderator: Viewer) {
+		const action = approved ? "approved" : "denied";
+		this.#text = `${this.#name(moderator)} ${action} ${this.#name(user)}'s unban request`;
+
+		return this;
+	}
+
+	/**
 	 * Sets the text of the system message when a user's timeout is removed.
 	 *
 	 * `{moderator} removed timeout on {user}`
@@ -180,11 +193,9 @@ export class SystemMessage extends Message {
 	}
 
 	#name(user: PartialUser) {
-		return html`
-			<span class="font-semibold" style="color: ${user.color};">
-				${user.displayName}
-			</span>
-		`;
+		return html`<span class="font-semibold" style="color: ${user.color};"
+			>${user.displayName}</span
+		>`;
 	}
 
 	public setText(text: string) {

--- a/src/lib/message/system-message.ts
+++ b/src/lib/message/system-message.ts
@@ -79,6 +79,29 @@ export class SystemMessage extends Message {
 	}
 
 	/**
+	 * Sets the text of the system message when the chat mode is changed for
+	 * `channel.moderate` events.
+	 *
+	 * `{moderator} enabled/disabled {duration?} {mode} [chat]`
+	 */
+	public mode(
+		mode: string,
+		disabled: boolean,
+		seconds: number,
+		moderator: Viewer,
+	) {
+		const duration = Number.isNaN(seconds) ? "" : formatDuration(seconds);
+
+		this.#text = "";
+		this.#text += `${this.#name(moderator)} `;
+		this.#text += disabled ? "disabled " : "enabled ";
+		this.#text += duration;
+		this.#text += mode === "slow" ? "slow mode" : `${mode} chat`;
+
+		return this;
+	}
+
+	/**
 	 * Sets the text of the system message when a user is timed out in a
 	 * channel.
 	 *

--- a/src/lib/message/system-message.ts
+++ b/src/lib/message/system-message.ts
@@ -60,6 +60,32 @@ export class SystemMessage extends Message {
 		return this;
 	}
 
+	/**
+	 * Sets the text of the system message when the chat is cleared.
+	 *
+	 * - `The chat has been cleared for non-moderator viewers` for `CLEARCHAT`
+	 *   messages
+	 * - `{moderator} cleared the chat for non-moderator viewers` for
+	 *   `channel.moderate` events
+	 */
+	public clear(moderator?: Viewer) {
+		this.#text = moderator
+			? `${this.#name(moderator)} cleared the chat`
+			: `The chat has been cleared`;
+
+		this.#text += " for non-moderator viewers";
+
+		return this;
+	}
+
+	/**
+	 * Sets the text of the system message when a user is timed out in a
+	 * channel.
+	 *
+	 * - `{user} has been timed out for {duration}` for `CLEARCHAT` messages
+	 * - `{moderator} timed out {user} for {duration}` for `channel.moderate`
+	 *   events
+	 */
 	public timeout(seconds: number, user: Viewer, moderator?: Viewer) {
 		const target = this.#name(user);
 		const duration = formatDuration(seconds);

--- a/src/lib/message/system-message.ts
+++ b/src/lib/message/system-message.ts
@@ -1,3 +1,4 @@
+import type { AutomodTermsMetadata } from "$lib/twitch/eventsub";
 import type { PartialUser } from "$lib/user";
 import { formatDuration } from "$lib/util";
 import type { Viewer } from "$lib/viewer.svelte";
@@ -42,6 +43,27 @@ export class SystemMessage extends Message {
 
 	public override get text() {
 		return this.#text;
+	}
+
+	/**
+	 * Sets the text of the system message when a term is added or removed to
+	 * the blocked or permitted list.
+	 *
+	 * `{moderator} added/removed [a] blocked/permitted term[s][ (via AutoMod)]: {term[, ]}`
+	 */
+	public term(data: AutomodTermsMetadata, moderator: Viewer) {
+		const action = data.action === "add" ? "added" : "removed";
+		const viaAutoMod = data.from_automod ? " (via AutoMod)" : "";
+
+		this.#text = `${this.#name(moderator)} ${action} `;
+
+		if (data.terms.length === 1) {
+			this.#text += `a ${data.list} term${viaAutoMod}: ${data.terms[0]}`;
+		} else {
+			this.#text += `${data.terms.length} ${data.list} terms${viaAutoMod}: ${data.terms.join(", ")}`;
+		}
+
+		return this;
 	}
 
 	/**

--- a/src/lib/message/system-message.ts
+++ b/src/lib/message/system-message.ts
@@ -65,11 +65,11 @@ export class SystemMessage extends Message {
 		const action = banned ? "banned" : "unbanned";
 
 		this.#text = moderator
-			? `${this.#name(moderator)} ${action} ${target}`
-			: `${target} has been ${action}`;
+			? `${this.#name(moderator)} ${action} ${target}.`
+			: `${target} has been ${action}.`;
 
 		if (reason) {
-			this.#text += `: ${reason}`;
+			this.#text = `${this.#text.slice(0, -1)}: ${reason}`;
 		}
 
 		return this;
@@ -88,7 +88,7 @@ export class SystemMessage extends Message {
 			? `${this.#name(moderator)} cleared the chat`
 			: `The chat has been cleared`;
 
-		this.#text += " for non-moderator viewers";
+		this.#text += " for non-moderator viewers.";
 
 		return this;
 	}
@@ -109,7 +109,7 @@ export class SystemMessage extends Message {
 
 		this.#text = "";
 		this.#text += `${this.#name(moderator)} ${action} ${duration}`;
-		this.#text += mode === "slow" ? "slow mode" : `${mode} chat`;
+		this.#text += mode === "slow" ? "slow mode." : `${mode} chat.`;
 
 		return this;
 	}
@@ -127,7 +127,7 @@ export class SystemMessage extends Message {
 		broadcaster: Viewer,
 	) {
 		const action = added ? "added" : "removed";
-		this.#text = `${this.#name(broadcaster)} ${action} ${this.#name(user)} as a ${role}`;
+		this.#text = `${this.#name(broadcaster)} ${action} ${this.#name(user)} as a ${role}.`;
 
 		return this;
 	}
@@ -140,14 +140,14 @@ export class SystemMessage extends Message {
 	 */
 	public term(data: AutomodTermsMetadata, moderator: Viewer) {
 		const action = data.action === "add" ? "added" : "removed";
-		const viaAutoMod = data.from_automod ? " (via AutoMod)" : "";
+		const via = data.from_automod ? " (via AutoMod)" : "";
 
 		this.#text = `${this.#name(moderator)} ${action} `;
 
 		if (data.terms.length === 1) {
-			this.#text += `a ${data.list} term${viaAutoMod}: ${data.terms[0]}`;
+			this.#text += `a ${data.list} term${via}: ${data.terms[0]}`;
 		} else {
-			this.#text += `${data.terms.length} ${data.list} terms${viaAutoMod}: ${data.terms.join(", ")}`;
+			this.#text += `${data.terms.length} ${data.list} terms${via}: ${data.terms.join(", ")}`;
 		}
 
 		return this;
@@ -170,11 +170,11 @@ export class SystemMessage extends Message {
 		const duration = formatDuration(seconds);
 
 		this.#text = moderator
-			? `${this.#name(moderator)} timed out ${target} for ${duration}`
-			: `${target} has been timed out for ${duration}`;
+			? `${this.#name(moderator)} timed out ${target} for ${duration}.`
+			: `${target} has been timed out for ${duration}.`;
 
 		if (reason) {
-			this.#text += `: ${reason}`;
+			this.#text = `${this.#text.slice(0, -1)}: ${reason}`;
 		}
 
 		return this;
@@ -190,7 +190,7 @@ export class SystemMessage extends Message {
 		const user = Viewer.from(request);
 		const action = request.is_approved ? "approved" : "denied";
 
-		this.#text = `${this.#name(moderator)} ${action} ${this.#name(user)}'s unban request`;
+		this.#text = `${this.#name(moderator)} ${action} ${this.#name(user)}'s unban request.`;
 		return this;
 	}
 
@@ -200,7 +200,7 @@ export class SystemMessage extends Message {
 	 * `{moderator} removed timeout on {user}`
 	 */
 	public untimeout(user: Viewer, moderator: Viewer) {
-		this.#text = `${this.#name(moderator)} removed timeout on ${this.#name(user)}`;
+		this.#text = `${this.#name(moderator)} removed timeout on ${this.#name(user)}.`;
 		return this;
 	}
 
@@ -211,7 +211,7 @@ export class SystemMessage extends Message {
 	 */
 	public warn(warning: WarnMetadata, moderator: Viewer) {
 		const user = Viewer.from(warning);
-		this.#text = `${this.#name(moderator)} warned ${this.#name(user)}`;
+		this.#text = `${this.#name(moderator)} warned ${this.#name(user)}.`;
 
 		if (warning.reason || warning.chat_rules_cited) {
 			const reasons = [
@@ -221,7 +221,7 @@ export class SystemMessage extends Message {
 				.filter((r) => r !== null)
 				.join(", ");
 
-			this.#text += `: ${reasons}`;
+			this.#text = `${this.#text.slice(0, -1)}: ${reasons}`;
 		}
 
 		return this;

--- a/src/lib/message/system-message.ts
+++ b/src/lib/message/system-message.ts
@@ -1,4 +1,5 @@
 import type { PartialUser } from "$lib/user";
+import { formatDuration } from "$lib/util";
 import type { Viewer } from "$lib/viewer.svelte";
 import { Message } from "./message";
 
@@ -55,6 +56,17 @@ export class SystemMessage extends Message {
 		this.#text = moderator
 			? `${this.#name(moderator)} banned ${target}`
 			: `${target} has been banned`;
+
+		return this;
+	}
+
+	public timeout(seconds: number, user: Viewer, moderator?: Viewer) {
+		const target = this.#name(user);
+		const duration = formatDuration(seconds);
+
+		this.#text = moderator
+			? `${this.#name(moderator)} timed out ${target} for ${duration}`
+			: `${target} has been timed out for ${duration}`;
 
 		return this;
 	}

--- a/src/lib/message/system-message.ts
+++ b/src/lib/message/system-message.ts
@@ -45,8 +45,7 @@ export class SystemMessage extends Message {
 	}
 
 	/**
-	 * Sets the text of the system message when a user is banned or unbanned in
-	 * a channel.
+	 * Sets the text of the system message when a user is banned or unbanned.
 	 *
 	 * - `{user} has been banned/unbanned` for `CLEARCHAT` messages
 	 * - `{moderator} banned/unbanned {user}` for `channel.moderate` events
@@ -81,8 +80,7 @@ export class SystemMessage extends Message {
 	}
 
 	/**
-	 * Sets the text of the system message when the chat mode is changed for
-	 * `channel.moderate` events.
+	 * Sets the text of the system message when the chat mode is changed.
 	 *
 	 * `{moderator} enabled/disabled {duration?} {mode} [chat]`
 	 */
@@ -104,8 +102,25 @@ export class SystemMessage extends Message {
 	}
 
 	/**
-	 * Sets the text of the system message when a user is timed out in a
-	 * channel.
+	 * Sets the text of the system message when a user is added or removed as a
+	 * moderator or VIP.
+	 *
+	 * `{broadcaster} added/removed {user} as a moderator/VIP`
+	 */
+	public roleStatus(
+		role: string,
+		removed: boolean,
+		user: Viewer,
+		broadcaster: Viewer,
+	) {
+		const action = removed ? "removed" : "added";
+		this.#text = `${this.#name(broadcaster)} ${action} ${this.#name(user)} as a ${role}`;
+
+		return this;
+	}
+
+	/**
+	 * Sets the text of the system message when a user is timed out.
 	 *
 	 * - `{user} has been timed out for {duration}` for `CLEARCHAT` messages
 	 * - `{moderator} timed out {user} for {duration}` for `channel.moderate`
@@ -122,6 +137,11 @@ export class SystemMessage extends Message {
 		return this;
 	}
 
+	/**
+	 * Sets the text of the system message when a user's timeout is removed.
+	 *
+	 * `{moderator} removed timeout on {user}`
+	 */
 	public untimeout(user: Viewer, moderator: Viewer) {
 		this.#text = `${this.#name(moderator)} removed timeout on ${this.#name(user)}`;
 		return this;

--- a/src/lib/message/system-message.ts
+++ b/src/lib/message/system-message.ts
@@ -46,35 +46,14 @@ export class SystemMessage extends Message {
 	}
 
 	/**
-	 * Sets the text of the system message when a term is added or removed to
-	 * the blocked or permitted list.
-	 *
-	 * `{moderator} added/removed [a] blocked/permitted term[s][ (via AutoMod)]: {term[, ]}`
-	 */
-	public term(data: AutomodTermsMetadata, moderator: Viewer) {
-		const action = data.action === "add" ? "added" : "removed";
-		const viaAutoMod = data.from_automod ? " (via AutoMod)" : "";
-
-		this.#text = `${this.#name(moderator)} ${action} `;
-
-		if (data.terms.length === 1) {
-			this.#text += `a ${data.list} term${viaAutoMod}: ${data.terms[0]}`;
-		} else {
-			this.#text += `${data.terms.length} ${data.list} terms${viaAutoMod}: ${data.terms.join(", ")}`;
-		}
-
-		return this;
-	}
-
-	/**
 	 * Sets the text of the system message when a user is banned or unbanned.
 	 *
 	 * - `{user} has been banned/unbanned` for `CLEARCHAT` messages
 	 * - `{moderator} banned/unbanned {user}` for `channel.moderate` events
 	 */
-	public banStatus(unbanned: boolean, user: Viewer, moderator?: Viewer) {
+	public banStatus(banned: boolean, user: Viewer, moderator?: Viewer) {
 		const target = this.#name(user);
-		const action = unbanned ? "unbanned" : "banned";
+		const action = banned ? "banned" : "unbanned";
 
 		this.#text = moderator
 			? `${this.#name(moderator)} ${action} ${target}`
@@ -108,16 +87,15 @@ export class SystemMessage extends Message {
 	 */
 	public mode(
 		mode: string,
-		disabled: boolean,
+		enabled: boolean,
 		seconds: number,
 		moderator: Viewer,
 	) {
+		const action = enabled ? "enabled" : "disabled";
 		const duration = Number.isNaN(seconds) ? "" : formatDuration(seconds);
 
 		this.#text = "";
-		this.#text += `${this.#name(moderator)} `;
-		this.#text += disabled ? "disabled " : "enabled ";
-		this.#text += duration;
+		this.#text += `${this.#name(moderator)} ${action} ${duration}`;
 		this.#text += mode === "slow" ? "slow mode" : `${mode} chat`;
 
 		return this;
@@ -131,12 +109,33 @@ export class SystemMessage extends Message {
 	 */
 	public roleStatus(
 		role: string,
-		removed: boolean,
+		added: boolean,
 		user: Viewer,
 		broadcaster: Viewer,
 	) {
-		const action = removed ? "removed" : "added";
+		const action = added ? "added" : "removed";
 		this.#text = `${this.#name(broadcaster)} ${action} ${this.#name(user)} as a ${role}`;
+
+		return this;
+	}
+
+	/**
+	 * Sets the text of the system message when a term is added or removed to
+	 * the blocked or permitted list.
+	 *
+	 * `{moderator} added/removed [a] blocked/permitted term[s][ (via AutoMod)]: {term[, ]}`
+	 */
+	public term(data: AutomodTermsMetadata, moderator: Viewer) {
+		const action = data.action === "add" ? "added" : "removed";
+		const viaAutoMod = data.from_automod ? " (via AutoMod)" : "";
+
+		this.#text = `${this.#name(moderator)} ${action} `;
+
+		if (data.terms.length === 1) {
+			this.#text += `a ${data.list} term${viaAutoMod}: ${data.terms[0]}`;
+		} else {
+			this.#text += `${data.terms.length} ${data.list} terms${viaAutoMod}: ${data.terms.join(", ")}`;
+		}
 
 		return this;
 	}

--- a/src/lib/message/system-message.ts
+++ b/src/lib/message/system-message.ts
@@ -45,17 +45,19 @@ export class SystemMessage extends Message {
 	}
 
 	/**
-	 * Sets the text of the system message when a user is banned in a channel.
+	 * Sets the text of the system message when a user is banned or unbanned in
+	 * a channel.
 	 *
-	 * - `{user} has been banned` for `CLEARCHAT` messages
-	 * - `{moderator} banned {user}` for `channel.moderate` events
+	 * - `{user} has been banned/unbanned` for `CLEARCHAT` messages
+	 * - `{moderator} banned/unbanned {user}` for `channel.moderate` events
 	 */
-	public ban(user: Viewer, moderator?: Viewer) {
+	public banStatus(unbanned: boolean, user: Viewer, moderator?: Viewer) {
 		const target = this.#name(user);
+		const action = unbanned ? "unbanned" : "banned";
 
 		this.#text = moderator
-			? `${this.#name(moderator)} banned ${target}`
-			: `${target} has been banned`;
+			? `${this.#name(moderator)} ${action} ${target}`
+			: `${target} has been ${action}`;
 
 		return this;
 	}
@@ -117,6 +119,11 @@ export class SystemMessage extends Message {
 			? `${this.#name(moderator)} timed out ${target} for ${duration}`
 			: `${target} has been timed out for ${duration}`;
 
+		return this;
+	}
+
+	public untimeout(user: Viewer, moderator: Viewer) {
+		this.#text = `${this.#name(moderator)} removed timeout on ${this.#name(user)}`;
 		return this;
 	}
 

--- a/src/lib/message/user-message.svelte.ts
+++ b/src/lib/message/user-message.svelte.ts
@@ -79,7 +79,7 @@ export class UserMessage extends Message {
 
 		// prettier-ignore
 		return (
-			app.user.moderating.has(app.active.user.id) &&
+			app.user.moderating.has(app.active.user.username) &&
 			diff <= 6 * 60 * 60 * 1000 &&
 			(
 				app.user.id === this.viewer.id ||

--- a/src/lib/message/user-message.svelte.ts
+++ b/src/lib/message/user-message.svelte.ts
@@ -48,6 +48,19 @@ export class UserMessage extends Message {
 		this.fragments = this.#fragment();
 	}
 
+	public override get id() {
+		return this.data.message_id;
+	}
+
+	public override get text() {
+		// message_text should only be possibly null if it's a USERNOTICE, in
+		// which case we can assume system_message is present
+		return (
+			this.data.message_text ??
+			(this.data as UserNoticeMessage).system_message
+		);
+	}
+
 	/**
 	 * Whether the current user can perform mod actions on the message.
 	 *
@@ -111,13 +124,6 @@ export class UserMessage extends Message {
 	}
 
 	/**
-	 * Whether the message was retreived by the `recent-messages` API.
-	 */
-	public get isRecent() {
-		return this.data.is_recent;
-	}
-
-	/**
 	 * The event associated with the message if it's a `USERNOTICE` message.
 	 */
 	public get event() {
@@ -140,7 +146,7 @@ export class UserMessage extends Message {
 				id: this.data.sender.id,
 				username: this.data.sender.login,
 				displayName: this.data.sender.name,
-				color: this.data.name_color || "inherit",
+				color: this.data.name_color,
 			});
 		}
 

--- a/src/lib/twitch/eventsub.ts
+++ b/src/lib/twitch/eventsub.ts
@@ -17,7 +17,7 @@ export interface ActionMetadata {
 	user_login: string;
 }
 
-export interface AutomodTermsMetadata extends ActionMetadata {
+export interface AutomodTermsMetadata {
 	action: "add" | "remove";
 	list: "blocked" | "permitted";
 	terms: string[];
@@ -33,7 +33,7 @@ export interface DeleteMetadata extends ActionMetadata {
 	message_body: string;
 }
 
-export interface FollowersMetadata extends ActionMetadata {
+export interface FollowersMetadata {
 	follow_duration_minutes: number;
 }
 
@@ -41,7 +41,7 @@ export interface RaidMetadata extends ActionMetadata {
 	viewer_count: number;
 }
 
-export interface SlowMetadata extends ActionMetadata {
+export interface SlowMetadata {
 	wait_time_seconds: number;
 }
 
@@ -77,8 +77,8 @@ export interface DeleteAction extends BaseAction<"delete"> {
 export type EmoteOnlyAction = BaseAction<"emoteonly" | "emoteonlyoff">;
 
 export interface FollowersAction
-	extends BaseAction<"followers" | "followers_off"> {
-	followers: FollowersMetadata;
+	extends BaseAction<"followers" | "followersoff"> {
+	followers: FollowersMetadata | null;
 }
 
 export interface ModAction extends BaseAction<"mod"> {
@@ -90,7 +90,7 @@ export interface RaidAction extends BaseAction<"raid"> {
 }
 
 export interface SlowAction extends BaseAction<"slow" | "slowoff"> {
-	slow: SlowMetadata;
+	slow: SlowMetadata | null;
 }
 
 export type SubscribersAction = BaseAction<"subscribers" | "subscribersoff">;
@@ -108,7 +108,7 @@ export interface UnbanRequestAction
 	unban_request: UnbanRequestMetadata;
 }
 
-export type UniqueAction = BaseAction<"unique" | "uniqueoff">;
+export type UniqueAction = BaseAction<"uniquechat" | "uniquechatoff">;
 
 export interface UnmodAction extends BaseAction<"unmod"> {
 	unmod: ActionMetadata;

--- a/src/lib/twitch/eventsub.ts
+++ b/src/lib/twitch/eventsub.ts
@@ -1,0 +1,163 @@
+export interface BaseAction<A extends string> {
+	action: A;
+	broadcaster_user_id: string;
+	broadcaster_user_login: string;
+	broadcaster_user_name: string;
+	source_broadcaster_user_id: string;
+	source_broadcaster_user_login: string;
+	source_broadcaster_user_name: string;
+	moderator_user_id: string;
+	moderator_user_login: string;
+	moderator_user_name: string;
+}
+
+export interface ActionMetadata {
+	user_id: string;
+	user_name: string;
+	user_login: string;
+}
+
+export interface AutomodTermsMetadata extends ActionMetadata {
+	action: "add" | "remove";
+	list: "blocked" | "permitted";
+	terms: string[];
+	from_automod: boolean;
+}
+
+export interface BanMetadata extends ActionMetadata {
+	reason: string | null;
+}
+
+export interface DeleteMetadata extends ActionMetadata {
+	message_id: string;
+	message_body: string;
+}
+
+export interface FollowersMetadata extends ActionMetadata {
+	follow_duration_minutes: number;
+}
+
+export interface RaidMetadata extends ActionMetadata {
+	viewer_count: number;
+}
+
+export interface SlowMetadata extends ActionMetadata {
+	wait_time_seconds: number;
+}
+
+export interface TimeoutMetadata extends BanMetadata {
+	expires_at: string;
+}
+
+export interface UnbanRequestMetadata extends ActionMetadata {
+	is_approved: boolean;
+	moderator_message: string;
+}
+
+export interface AutomodTermsAction
+	extends BaseAction<
+		| "add_blocked_term"
+		| "add_permitted_term"
+		| "remove_blocked_term"
+		| "remove_permitted_term"
+	> {
+	automod_terms: AutomodTermsMetadata;
+}
+
+export interface BanAction extends BaseAction<"ban"> {
+	ban: BanMetadata;
+}
+
+export type ClearAction = BaseAction<"clear">;
+
+export interface DeleteAction extends BaseAction<"delete"> {
+	delete: DeleteMetadata;
+}
+
+export type EmoteOnlyAction = BaseAction<"emoteonly" | "emoteonlyoff">;
+
+export interface FollowersAction
+	extends BaseAction<"followers" | "followers_off"> {
+	followers: FollowersMetadata;
+}
+
+export interface ModAction extends BaseAction<"mod"> {
+	mod: ActionMetadata;
+}
+
+export interface RaidAction extends BaseAction<"raid"> {
+	raid: RaidMetadata;
+}
+
+export interface SlowAction extends BaseAction<"slow" | "slowoff"> {
+	slow: SlowMetadata;
+}
+
+export type SubscribersAction = BaseAction<"subscribers" | "subscribersoff">;
+
+export interface TimeoutAction extends BaseAction<"timeout"> {
+	timeout: TimeoutMetadata;
+}
+
+export interface UnbanAction extends BaseAction<"unban"> {
+	unban: ActionMetadata;
+}
+
+export interface UnbanRequestAction
+	extends BaseAction<"approve_unban_request" | "deny_unban_request"> {
+	unban_request: UnbanRequestMetadata;
+}
+
+export type UniqueAction = BaseAction<"unique" | "uniqueoff">;
+
+export interface UnmodAction extends BaseAction<"unmod"> {
+	unmod: ActionMetadata;
+}
+
+export interface UnraidAction extends BaseAction<"unraid"> {
+	unraid: ActionMetadata;
+}
+
+export interface UntimeoutAction extends BaseAction<"untimeout"> {
+	untimeout: ActionMetadata;
+}
+
+export interface UnvipAction extends BaseAction<"unvip"> {
+	unvip: ActionMetadata;
+}
+
+export interface VipAction extends BaseAction<"vip"> {
+	vip: ActionMetadata;
+}
+
+export type ChannelModerate =
+	| AutomodTermsAction
+	| BanAction
+	| ClearAction
+	| DeleteAction
+	| EmoteOnlyAction
+	| FollowersAction
+	| ModAction
+	| RaidAction
+	| SlowAction
+	| SubscribersAction
+	| TimeoutAction
+	| UnbanAction
+	| UnbanRequestAction
+	| UniqueAction
+	| UnmodAction
+	| UnraidAction
+	| UntimeoutAction
+	| UnvipAction
+	| VipAction;
+
+export type SubscriptionEvent = ChannelModerate;
+
+export interface NotificationPayload {
+	subscription: { type: string };
+	event: SubscriptionEvent;
+}
+
+export interface SubscriptionEventMap {
+	"channel.moderate": ChannelModerate;
+}

--- a/src/lib/twitch/eventsub.ts
+++ b/src/lib/twitch/eventsub.ts
@@ -54,6 +54,11 @@ export interface UnbanRequestMetadata extends ActionMetadata {
 	moderator_message: string;
 }
 
+export interface WarnMetadata extends ActionMetadata {
+	reason: string | null;
+	chat_rules_cited: string[] | null;
+}
+
 export interface AutomodTermsAction
 	extends BaseAction<
 		| "add_blocked_term"
@@ -130,6 +135,10 @@ export interface VipAction extends BaseAction<"vip"> {
 	vip: ActionMetadata;
 }
 
+export interface WarnAction extends BaseAction<"warn"> {
+	warn: WarnMetadata;
+}
+
 export type ChannelModerate =
 	| AutomodTermsAction
 	| BanAction
@@ -149,7 +158,8 @@ export type ChannelModerate =
 	| UnraidAction
 	| UntimeoutAction
 	| UnvipAction
-	| VipAction;
+	| VipAction
+	| WarnAction;
 
 export type SubscriptionEvent = ChannelModerate;
 

--- a/src/lib/twitch/index.ts
+++ b/src/lib/twitch/index.ts
@@ -1,7 +1,7 @@
 import { Channel, invoke } from "@tauri-apps/api/core";
 import { handlers } from "$lib/handlers";
-import type { IrcMessage } from "./irc";
 import type { NotificationPayload } from "./eventsub";
+import type { IrcMessage } from "./irc";
 
 export const SCOPES = [
 	// Channel

--- a/src/lib/twitch/irc.ts
+++ b/src/lib/twitch/irc.ts
@@ -194,8 +194,49 @@ export interface UserNoticeMessage extends BaseUserMessage {
 	event_id: string;
 }
 
+export type NoticeMessageId =
+	| "emote_only_on"
+	| "emote_only_off"
+	| "followers_on"
+	| "followers_on_zero"
+	| "followers_off"
+	| "msg_banned"
+	| "msg_bad_characters"
+	| "msg_channel_blocked"
+	| "msg_channel_suspended"
+	| "msg_duplicate"
+	| "msg_emotesonly"
+	| "msg_followersonly"
+	| "msg_followersonly_followed"
+	| "msg_followersonly_zero"
+	| "msg_r9k"
+	| "msg_ratelimit"
+	| "msg_rejected"
+	| "msg_rejected_mandatory"
+	| "msg_requires_verified_phone_number"
+	| "msg_slowmode"
+	| "msg_subsonly"
+	| "msg_suspended"
+	| "msg_timedout"
+	| "msg_verified_email"
+	| "r9k_on"
+	| "r9k_off"
+	| "slow_on"
+	| "slow_off"
+	| "subs_on"
+	| "subs_off"
+	| "tos_ban"
+	| "unrecognized_cmd"
+	| ({} & string);
+
 export interface NoticeMessage {
 	type: "notice";
+	channel_login: string;
+	message_text: string;
+	message_id: NoticeMessageId;
+	deleted: boolean;
+	is_recent: boolean;
+	recent_timestamp: number | null;
 }
 
 export interface PartMessage {

--- a/src/lib/twitch/irc.ts
+++ b/src/lib/twitch/irc.ts
@@ -4,6 +4,32 @@ export interface JoinMessage {
 	user_login: string;
 }
 
+export interface ClearChatClear {
+	type: "clear";
+}
+
+export interface ClearChatBan {
+	type: "ban";
+	user_login: string;
+	user_id: string;
+}
+
+export interface ClearChatTimeout extends Omit<ClearChatBan, "type"> {
+	type: "timeout";
+	duration: { secs: number };
+}
+
+export type ClearChatAction = ClearChatClear | ClearChatBan | ClearChatTimeout;
+
+export interface ClearChatMessage {
+	type: "clearchat";
+	channel_login: string;
+	channel_id: string;
+	action: ClearChatAction;
+	is_recent: boolean;
+	server_timestamp: number;
+}
+
 export interface ClearMsgMessage {
 	type: "clearmsg";
 	channel_login: string;
@@ -11,7 +37,7 @@ export interface ClearMsgMessage {
 	message_id: string;
 	message_text: string;
 	is_action: boolean;
-	server_timestamp: boolean;
+	server_timestamp: number;
 }
 
 export interface BasicUser {
@@ -47,7 +73,7 @@ export interface BaseUserMessage {
 	message_id: string;
 	deleted: boolean;
 	is_recent: boolean;
-	server_timestamp: string;
+	server_timestamp: number;
 }
 
 export interface ReplyParent {
@@ -180,6 +206,7 @@ export interface PartMessage {
 
 export type IrcMessage =
 	| JoinMessage
+	| ClearChatMessage
 	| ClearMsgMessage
 	| PrivmsgMessage
 	| UserNoticeMessage

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -5,7 +5,7 @@ import type { User as HelixUser } from "./twitch/api";
 
 export interface PartialUser {
 	id: string;
-	color: string;
+	color?: string;
 	username: string;
 	displayName: string;
 }

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -15,7 +15,7 @@ export class User implements PartialUser {
 	#color: string | null = null;
 
 	/**
-	 * A set of channel ids that the user is a moderator in.
+	 * A set of channel usernames that the user is a moderator in.
 	 */
 	public readonly moderating = new SvelteSet<string>();
 
@@ -23,7 +23,7 @@ export class User implements PartialUser {
 		this.#data = data.data;
 		this.#color = data.color;
 
-		this.moderating.add(this.id);
+		this.moderating.add(this.username);
 	}
 
 	public static async from(id: string | null = null): Promise<User> {
@@ -31,7 +31,7 @@ export class User implements PartialUser {
 		const user = new User(data);
 
 		const channels = await invoke<string[]>("get_moderated_channels");
-		channels.forEach((id) => user.moderating.add(id));
+		channels.forEach((name) => user.moderating.add(name));
 
 		return user;
 	}

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -8,6 +8,34 @@ export function cn(...values: ClassValue[]) {
 	return twMerge(clsx(values));
 }
 
+export function formatDuration(seconds: number) {
+	const parts: string[] = [];
+
+	const days = Math.floor(seconds / 86400);
+	if (days) {
+		parts.push(`${days}d`);
+		seconds %= 86400;
+	}
+
+	const hours = Math.floor(seconds / 3600);
+	if (hours) {
+		parts.push(`${hours}h`);
+		seconds %= 3600;
+	}
+
+	const minutes = Math.floor(seconds / 60);
+	if (minutes) {
+		parts.push(`${minutes}m`);
+		seconds %= 60;
+	}
+
+	if (seconds || !parts.length) {
+		parts.push(`${seconds}s`);
+	}
+
+	return parts.join(" ");
+}
+
 export function formatTime(timestamp: Date) {
 	const date = dayjs(timestamp);
 

--- a/src/lib/viewer.svelte.ts
+++ b/src/lib/viewer.svelte.ts
@@ -1,3 +1,4 @@
+import { app } from "./state.svelte";
 import type { ActionMetadata } from "./twitch/eventsub";
 import type { PartialUser } from "./user";
 
@@ -24,11 +25,16 @@ export class Viewer implements PartialUser {
 	}
 
 	public static from(metadata: ActionMetadata) {
-		return new Viewer({
-			id: metadata.user_id,
-			username: metadata.user_login,
-			displayName: metadata.user_name,
-		});
+		const stored = app.active.viewers.get(metadata.user_login);
+
+		return (
+			stored ??
+			new Viewer({
+				id: metadata.user_id,
+				username: metadata.user_login,
+				displayName: metadata.user_name,
+			})
+		);
 	}
 
 	public get id() {

--- a/src/lib/viewer.svelte.ts
+++ b/src/lib/viewer.svelte.ts
@@ -1,3 +1,4 @@
+import type { ActionMetadata } from "./twitch/eventsub";
 import type { PartialUser } from "./user";
 
 export class Viewer implements PartialUser {
@@ -22,12 +23,20 @@ export class Viewer implements PartialUser {
 		this.#data = data;
 	}
 
+	public static from(metadata: ActionMetadata) {
+		return new Viewer({
+			id: metadata.user_id,
+			username: metadata.user_login,
+			displayName: metadata.user_name,
+		});
+	}
+
 	public get id() {
 		return this.#data.id;
 	}
 
 	public get color() {
-		return this.#data.color || "inherit";
+		return this.#data.color ?? "inherit";
 	}
 
 	public get username() {


### PR DESCRIPTION
This only fires if the user is a moderator in the channel, otherwise the subscription will silently fail. Rely on `CLEARCHAT`/`NOTICE` commands as a fallback.