### PR TITLE
refactor: use snippets to render system messages

### DIFF
--- a/src/lib/components/Chat.svelte
+++ b/src/lib/components/Chat.svelte
@@ -67,7 +67,7 @@
 		{#snippet children(message: Message, i)}
 			{#if !message.isUser()}
 				{/* @ts-expect-error */ null}
-				<SystemMessage {message} />
+				<SystemMessage {message} context={message.context} />
 			{:else if message.event}
 				<Notification {message} />
 			{:else}

--- a/src/lib/components/message/SystemMessage.svelte
+++ b/src/lib/components/message/SystemMessage.svelte
@@ -1,11 +1,184 @@
 <script lang="ts">
 	import { SystemMessage } from "$lib/message";
+	import type {
+		BanStatusContext,
+		ClearContext,
+		DeleteContext,
+		ModeContext,
+		RoleStatusContext,
+		StreamStatusContext,
+		SuspicionStatusContext,
+		SystemMessageContext,
+		TermContext,
+		TimeoutContext,
+		UnbanRequestContext,
+		WarnContext,
+	} from "$lib/message";
+	import { colorizeName, formatDuration } from "$lib/util";
 	import Timestamp from "../Timestamp.svelte";
 
-	const { message }: { message: SystemMessage } = $props();
+	interface Props {
+		message: SystemMessage;
+		context: SystemMessageContext | null;
+	}
+
+	const { message, context: ctx }: Props = $props();
+
+	// Make these nonreactive
+	// svelte-ignore non_reactive_update
+	let monitored = false;
+	// svelte-ignore non_reactive_update
+	let restricted = false;
+
+	if (ctx?.type === "suspicionStatus") {
+		monitored = ctx.user.monitored;
+		restricted = ctx.user.restricted;
+	}
 </script>
 
 <div class={["text-muted-foreground px-3 py-2", message.deleted && "opacity-30"]}>
 	<Timestamp date={message.timestamp} />
-	<p class="inline">{@html message.text}</p>
+
+	<p class="inline">
+		{#if ctx}
+			{#if ctx.type === "banStatus"}
+				{@render banStatus(ctx)}
+			{:else if ctx.type === "clear"}
+				{@render clear(ctx)}
+			{:else if ctx.type === "delete"}
+				{@render deleteMsg(ctx)}
+			{:else if ctx.type === "join"}
+				Joined {@html colorizeName(ctx.channel)}
+			{:else if ctx.type === "mode"}
+				{@render mode(ctx)}
+			{:else if ctx.type === "roleStatus"}
+				{@render roleStatus(ctx)}
+			{:else if ctx.type === "streamStatus"}
+				{@render streamStatus(ctx)}
+			{:else if ctx.type === "suspicionStatus"}
+				{@render suspicionStatus(ctx)}
+			{:else if ctx.type === "term"}
+				{@render term(ctx)}
+			{:else if ctx.type === "timeout"}
+				{@render timeout(ctx)}
+			{:else if ctx.type === "unbanRequest"}
+				{@render unbanRequest(ctx)}
+			{:else if ctx.type === "untimeout"}
+				{@html colorizeName(ctx.moderator)} removed timeout on {@html colorizeName(
+					ctx.user,
+				)}.
+			{:else if ctx.type === "warn"}
+				{@render warn(ctx)}
+			{:else if ctx.type === "warnAck"}
+				{@html colorizeName(ctx.user)} acknowledged their warning.
+			{/if}
+		{:else}
+			{message.text}
+		{/if}
+	</p>
 </div>
+
+{#snippet banStatus(ctx: BanStatusContext)}
+	{@const target = colorizeName(ctx.user)}
+	{@const action = ctx.banned ? "banned" : "unbanned"}
+
+	{#if ctx.moderator}
+		{@html colorizeName(ctx.moderator)} {action} {@html target}
+	{:else}
+		{@html target} has been {action}
+	{/if}{ctx.reason ? `: ${ctx.reason}` : "."}
+{/snippet}
+
+{#snippet clear(ctx: ClearContext)}
+	{#if ctx.moderator}
+		{@html colorizeName(ctx.moderator)} cleared the chat
+	{:else}
+		The chat has been cleared
+	{/if}
+
+	for non-moderator viewers.
+{/snippet}
+
+{#snippet deleteMsg(ctx: DeleteContext)}
+	{@const target = colorizeName(ctx.user)}
+
+	{#if ctx.moderator}
+		{@html colorizeName(ctx.moderator)} deleted {@html target}'s message: {ctx.text}
+	{:else}
+		{@html target}'s message was deleted: {ctx.text}
+	{/if}
+{/snippet}
+
+{#snippet mode(ctx: ModeContext)}
+	{@html colorizeName(ctx.moderator)}
+	{ctx.enabled ? "enabled" : "disabled"}
+	{Number.isNaN(ctx.seconds) ? "" : formatDuration(ctx.seconds)}
+	{ctx.mode === "slow" ? "slow mode." : `${ctx.mode} chat.`}
+{/snippet}
+
+{#snippet roleStatus(ctx: RoleStatusContext)}
+	{@html colorizeName(ctx.broadcaster)}
+	{ctx.added ? "added" : "removed"}
+	{@html colorizeName(ctx.user)} as a {ctx.role}.
+{/snippet}
+
+{#snippet streamStatus(ctx: StreamStatusContext)}
+	{@html colorizeName(ctx.broadcaster)} is now {ctx.online ? "online" : "offline"}.
+{/snippet}
+
+{#snippet suspicionStatus(ctx: SuspicionStatusContext)}
+	{@html colorizeName(ctx.moderator)}
+	{ctx.active ? "started" : "stopped"}
+	{monitored ? "monitoring" : restricted ? "restricting" : ctx.previous}
+	{@html colorizeName(ctx.user)}'s messages.
+{/snippet}
+
+{#snippet term(ctx: TermContext)}
+	{@const via = ctx.data.from_automod ? " (via AutoMod)" : ""}
+
+	{@html colorizeName(ctx.moderator)}
+	{ctx.data.action === "add" ? "added" : "removed"}
+
+	{#if ctx.data.terms.length === 1}
+		a {ctx.data.list} term{via}: {ctx.data.terms[0]}
+	{:else}
+		{ctx.data.terms.length} {ctx.data.list} terms{via}: {ctx.data.terms.join(", ")}
+	{/if}
+{/snippet}
+
+{#snippet timeout(ctx: TimeoutContext)}
+	{@const target = colorizeName(ctx.user)}
+	{@const duration = formatDuration(ctx.seconds)}
+
+	{#if ctx.moderator}
+		{@html colorizeName(ctx.moderator)} timed out {@html target} for {duration}
+	{:else}
+		{@html target} has been timed out for {duration}
+	{/if}{ctx.reason ? `: ${ctx.reason}` : "."}
+{/snippet}
+
+{#snippet unbanRequest(ctx: UnbanRequestContext)}
+	{@const target = colorizeName(ctx.user)}
+
+	{#if "status" in ctx.request}
+		{#if !ctx.moderator}
+			{@html target}'s unban request was {ctx.request.status}.
+		{:else}
+			{@html colorizeName(ctx.moderator)}
+			{ctx.request.status}
+			{@html target}'s unban request{ctx.request.resolution_text
+				? `: ${ctx.request.resolution_text}`
+				: "."}
+		{/if}
+	{:else}
+		{@html target} submitted an unban request: {ctx.request.text}
+	{/if}
+{/snippet}
+
+{#snippet warn(ctx: WarnContext)}
+	{@const reasons = [ctx.warning.reason, ...(ctx.warning.chat_rules_cited ?? [])]
+		.filter((r) => r !== null)
+		.join(", ")}
+
+	{@html colorizeName(ctx.moderator)} warned {@html colorizeName(ctx.user)}: {reasons}
+{/snippet}

--- a/src/lib/handlers/eventsub/channel-suspicious-user-update.ts
+++ b/src/lib/handlers/eventsub/channel-suspicious-user-update.ts
@@ -22,7 +22,19 @@ export default defineHandler({
 			viewer.restricted = status === "restricted";
 		}
 
-		channel.addMessage(message.suspicionStatus(status !== "no_treatment", viewer, moderator));
+		channel.addMessage(
+			message.setContext({
+				type: "suspicionStatus",
+				active: status !== "no_treatment",
+				previous: viewer.monitored
+					? "monitoring"
+					: viewer.restricted
+						? "restricting"
+						: null,
+				user: viewer,
+				moderator,
+			}),
+		);
 
 		// Update AFTER message is sent so the previous status is available.
 		viewer.monitored = status === "active_monitoring";

--- a/src/lib/handlers/eventsub/channel-unban-request-create.ts
+++ b/src/lib/handlers/eventsub/channel-unban-request-create.ts
@@ -1,4 +1,5 @@
 import { SystemMessage } from "$lib/message";
+import { Viewer } from "$lib/viewer.svelte";
 import { defineHandler } from "../helper";
 
 export default defineHandler({
@@ -6,6 +7,12 @@ export default defineHandler({
 	handle(data, channel) {
 		const message = new SystemMessage();
 
-		channel.addMessage(message.unbanRequest(data));
+		channel.addMessage(
+			message.setContext({
+				type: "unbanRequest",
+				request: data,
+				user: Viewer.fromBasic(data),
+			}),
+		);
 	},
 });

--- a/src/lib/handlers/eventsub/channel-unban-request-resolve.ts
+++ b/src/lib/handlers/eventsub/channel-unban-request-resolve.ts
@@ -13,6 +13,13 @@ export default defineHandler({
 			moderator = Viewer.fromMod(data as WithModerator);
 		}
 
-		channel.addMessage(message.unbanRequest(data, moderator));
+		channel.addMessage(
+			message.setContext({
+				type: "unbanRequest",
+				request: data,
+				user: Viewer.fromBasic(data),
+				moderator,
+			}),
+		);
 	},
 });

--- a/src/lib/handlers/eventsub/channel-warning-acknowledge.ts
+++ b/src/lib/handlers/eventsub/channel-warning-acknowledge.ts
@@ -6,8 +6,12 @@ export default defineHandler({
 	name: "channel.warning.acknowledge",
 	handle(data, channel) {
 		const message = new SystemMessage();
-		const viewer = Viewer.fromBasic(data);
 
-		channel.addMessage(message.warnAck(viewer));
+		channel.addMessage(
+			message.setContext({
+				type: "warnAck",
+				user: Viewer.fromBasic(data),
+			}),
+		);
 	},
 });

--- a/src/lib/handlers/eventsub/stream-offline.ts
+++ b/src/lib/handlers/eventsub/stream-offline.ts
@@ -6,8 +6,13 @@ export default defineHandler({
 	name: "stream.offline",
 	handle(data, channel) {
 		const message = new SystemMessage();
-		const broadcaster = Viewer.fromBroadcaster(data);
 
-		channel.addMessage(message.streamStatus(false, broadcaster));
+		channel.addMessage(
+			message.setContext({
+				type: "streamStatus",
+				online: false,
+				broadcaster: Viewer.fromBroadcaster(data),
+			}),
+		);
 	},
 });

--- a/src/lib/handlers/eventsub/stream-online.ts
+++ b/src/lib/handlers/eventsub/stream-online.ts
@@ -6,8 +6,13 @@ export default defineHandler({
 	name: "stream.online",
 	handle(data, channel) {
 		const message = new SystemMessage();
-		const broadcaster = Viewer.fromBroadcaster(data);
 
-		channel.addMessage(message.streamStatus(true, broadcaster));
+		channel.addMessage(
+			message.setContext({
+				type: "streamStatus",
+				online: true,
+				broadcaster: Viewer.fromBroadcaster(data),
+			}),
+		);
 	},
 });

--- a/src/lib/handlers/irc/clearchat.ts
+++ b/src/lib/handlers/irc/clearchat.ts
@@ -16,7 +16,7 @@ export default defineHandler({
 
 		if (data.action.type === "clear") {
 			channel.clearMessages();
-			channel.addMessage(message.clear());
+			channel.addMessage(message.setContext({ type: "clear" }));
 			return;
 		}
 
@@ -31,9 +31,23 @@ export default defineHandler({
 		channel.clearMessages(target.id);
 
 		if (data.action.type === "ban") {
-			channel.addMessage(message.banStatus(false, null, target));
+			channel.addMessage(
+				message.setContext({
+					type: "banStatus",
+					banned: true,
+					reason: null,
+					user: target,
+				}),
+			);
 		} else {
-			channel.addMessage(message.timeout(data.action.duration.secs, null, target));
+			channel.addMessage(
+				message.setContext({
+					type: "timeout",
+					seconds: data.action.duration.secs,
+					reason: null,
+					user: target,
+				}),
+			);
 		}
 	},
 });

--- a/src/lib/handlers/irc/clearmsg.ts
+++ b/src/lib/handlers/irc/clearmsg.ts
@@ -16,7 +16,13 @@ export default defineHandler({
 		if (data.is_recent || (!data.is_recent && !app.user?.moderating.has(data.channel_login))) {
 			const sysmsg = new SystemMessage(data);
 
-			channel.addMessage(sysmsg.delete(data.message_text, message.viewer));
+			channel.addMessage(
+				sysmsg.setContext({
+					type: "delete",
+					text: data.message_text,
+					user: message.viewer,
+				}),
+			);
 		}
 	},
 });

--- a/src/lib/message/system-message.ts
+++ b/src/lib/message/system-message.ts
@@ -4,7 +4,6 @@ import type {
 	ChannelUnbanRequestResolve,
 	WarnMetadata,
 } from "$lib/twitch/eventsub";
-import { colorizeName, formatDuration } from "$lib/util";
 import { Viewer } from "$lib/viewer.svelte";
 import { Message } from "./message.svelte";
 
@@ -14,6 +13,116 @@ export interface SystemMessageData {
 	server_timestamp: number;
 }
 
+export interface BanStatusContext {
+	type: "banStatus";
+	banned: boolean;
+	reason: string | null;
+	user: Viewer;
+	moderator?: Viewer;
+}
+
+export interface ClearContext {
+	type: "clear";
+	moderator?: Viewer;
+}
+
+export interface DeleteContext {
+	type: "delete";
+	text: string;
+	user: Viewer;
+	moderator?: Viewer;
+}
+
+export interface JoinContext {
+	type: "join";
+	channel: Viewer;
+}
+
+export interface ModeContext {
+	type: "mode";
+	mode: string;
+	enabled: boolean;
+	seconds: number;
+	moderator: Viewer;
+}
+
+export interface RoleStatusContext {
+	type: "roleStatus";
+	role: string;
+	added: boolean;
+	user: Viewer;
+	broadcaster: Viewer;
+}
+
+export interface StreamStatusContext {
+	type: "streamStatus";
+	online: boolean;
+	broadcaster: Viewer;
+}
+
+export interface SuspicionStatusContext {
+	type: "suspicionStatus";
+	active: boolean;
+	previous: "monitoring" | "restricting" | null;
+	user: Viewer;
+	moderator: Viewer;
+}
+
+export interface TermContext {
+	type: "term";
+	data: AutomodTermsMetadata;
+	moderator: Viewer;
+}
+
+export interface TimeoutContext {
+	type: "timeout";
+	seconds: number;
+	reason: string | null;
+	user: Viewer;
+	moderator?: Viewer;
+}
+
+export interface UnbanRequestContext {
+	type: "unbanRequest";
+	request: ChannelUnbanRequestCreate | ChannelUnbanRequestResolve;
+	user: Viewer;
+	moderator?: Viewer;
+}
+
+export interface UntimeoutContext {
+	type: "untimeout";
+	user: Viewer;
+	moderator: Viewer;
+}
+
+export interface WarnContext {
+	type: "warn";
+	warning: WarnMetadata;
+	user: Viewer;
+	moderator: Viewer;
+}
+
+export interface WarnAckContext {
+	type: "warnAck";
+	user: Viewer;
+}
+
+export type SystemMessageContext =
+	| BanStatusContext
+	| ClearContext
+	| DeleteContext
+	| JoinContext
+	| ModeContext
+	| RoleStatusContext
+	| StreamStatusContext
+	| SuspicionStatusContext
+	| TermContext
+	| TimeoutContext
+	| UnbanRequestContext
+	| UntimeoutContext
+	| WarnContext
+	| WarnAckContext;
+
 /**
  * System messages are messages constructed internally and sent to relay
  * information to the user.
@@ -21,6 +130,8 @@ export interface SystemMessageData {
 export class SystemMessage extends Message {
 	#id = crypto.randomUUID();
 	#text = "";
+
+	public context: SystemMessageContext | null = null;
 
 	public constructor(data: Partial<SystemMessageData> = {}) {
 		const prepared: SystemMessageData = {
@@ -32,13 +143,9 @@ export class SystemMessage extends Message {
 		super(prepared, true);
 	}
 
-	/**
-	 * Creates a new system message with its text set to `Joined {channel}`.
-	 */
 	public static joined(channel: Viewer) {
 		const message = new SystemMessage();
-
-		return message.setText(`Joined ${colorizeName(channel)}`);
+		return message.setContext({ type: "join", channel });
 	}
 
 	public override get id() {
@@ -49,233 +156,8 @@ export class SystemMessage extends Message {
 		return this.#text;
 	}
 
-	/**
-	 * Sets the text of the system message when a user is banned or unbanned.
-	 *
-	 * - `{user} has been banned/unbanned` for `CLEARCHAT` messages
-	 * - `{moderator} banned/unbanned {user}[: {reason}]` for `channel.moderate` events
-	 */
-	public banStatus(banned: boolean, reason: string | null, user: Viewer, moderator?: Viewer) {
-		const target = colorizeName(user);
-		const action = banned ? "banned" : "unbanned";
-
-		this.#text = moderator
-			? `${colorizeName(moderator)} ${action} ${target}.`
-			: `${target} has been ${action}.`;
-
-		if (reason) {
-			this.#text = `${this.#text.slice(0, -1)}: ${reason}`;
-		}
-
-		return this;
-	}
-
-	/**
-	 * Sets the text of the system message when the chat is cleared.
-	 *
-	 * - `The chat has been cleared for non-moderator viewers` for `CLEARCHAT`
-	 *   messages
-	 * - `{moderator} cleared the chat for non-moderator viewers` for
-	 *   `channel.moderate` events
-	 */
-	public clear(moderator?: Viewer) {
-		this.#text = moderator
-			? `${colorizeName(moderator)} cleared the chat`
-			: `The chat has been cleared`;
-
-		this.#text += " for non-moderator viewers.";
-
-		return this;
-	}
-
-	/**
-	 * Sets the text of the system message when a user's message is deleted.
-	 *
-	 * - `{user}'s message was deleted: {text}` for `CLEARMSG` messages
-	 * - `{moderator} deleted {user}'s message: {text}` for `channel.moderate` events
-	 */
-	public delete(text: string, user: Viewer, moderator?: Viewer) {
-		if (moderator) {
-			this.#text = `${colorizeName(moderator)} deleted ${colorizeName(user)}'s message: ${text}`;
-		} else {
-			this.#text = `${colorizeName(user)}'s message was deleted: ${text}`;
-		}
-
-		return this;
-	}
-
-	/**
-	 * Sets the text of the system message when the chat mode is changed.
-	 *
-	 * `{moderator} enabled/disabled {duration?} {mode} [chat]`
-	 */
-	public mode(mode: string, enabled: boolean, seconds: number, moderator: Viewer) {
-		const action = enabled ? "enabled" : "disabled";
-		const duration = Number.isNaN(seconds) ? "" : formatDuration(seconds);
-
-		this.#text = `${colorizeName(moderator)} ${action} ${duration} `;
-		this.#text += mode === "slow" ? "slow mode." : `${mode} chat.`;
-
-		return this;
-	}
-
-	/**
-	 * Sets the text of the system message when a user is added or removed as a
-	 * moderator or VIP.
-	 *
-	 * `{broadcaster} added/removed {user} as a moderator/VIP`
-	 */
-	public roleStatus(role: string, added: boolean, user: Viewer, broadcaster: Viewer) {
-		const action = added ? "added" : "removed";
-		this.#text = `${colorizeName(broadcaster)} ${action} ${colorizeName(user)} as a ${role}.`;
-
-		return this;
-	}
-
-	/**
-	 * Sets the text of the system message when a stream goes online or offline.
-	 *
-	 * `{broadcaster} is now online/offline`
-	 */
-	public streamStatus(online: boolean, broadcaster: Viewer) {
-		const status = online ? "online" : "offline";
-		this.#text = `${colorizeName(broadcaster)} is now ${status}.`;
-
-		return this;
-	}
-
-	/**
-	 * Sets the text of the system message when a user's suspicion status is
-	 * updated.
-	 *
-	 * `{moderator} started/stopped monitoring/restricting {user}'s messages`
-	 */
-	public suspicionStatus(active: boolean, user: Viewer, moderator: Viewer) {
-		this.#text = `${colorizeName(moderator)} ${active ? "started" : "stopped"} `;
-
-		if (user.monitored) this.#text += "monitoring ";
-		else if (user.restricted) this.#text += "restricting ";
-
-		this.#text += `${colorizeName(user)}'s messages.`;
-		return this;
-	}
-
-	/**
-	 * Sets the text of the system message when a term is added or removed to
-	 * the blocked or permitted list.
-	 *
-	 * `{moderator} added/removed [a] blocked/permitted term[s][ (via AutoMod)]: {term[, ]}`
-	 */
-	public term(data: AutomodTermsMetadata, moderator: Viewer) {
-		const action = data.action === "add" ? "added" : "removed";
-		const via = data.from_automod ? " (via AutoMod)" : "";
-
-		this.#text = `${colorizeName(moderator)} ${action} `;
-
-		if (data.terms.length === 1) {
-			this.#text += `a ${data.list} term${via}: ${data.terms[0]}`;
-		} else {
-			this.#text += `${data.terms.length} ${data.list} terms${via}: ${data.terms.join(", ")}`;
-		}
-
-		return this;
-	}
-
-	/**
-	 * Sets the text of the system message when a user is timed out.
-	 *
-	 * - `{user} has been timed out for {duration}` for `CLEARCHAT` messages
-	 * - `{moderator} timed out {user} for {duration}[: {reason}]` for
-	 *   `channel.moderate` events
-	 */
-	public timeout(seconds: number, reason: string | null, user: Viewer, moderator?: Viewer) {
-		const target = colorizeName(user);
-		const duration = formatDuration(seconds);
-
-		this.#text = moderator
-			? `${colorizeName(moderator)} timed out ${target} for ${duration}.`
-			: `${target} has been timed out for ${duration}.`;
-
-		if (reason) {
-			this.#text = `${this.#text.slice(0, -1)}: ${reason}`;
-		}
-
-		return this;
-	}
-
-	/**
-	 * Sets the text of the system message when a user submits an unban request
-	 * or when a user's unban request is approved or denied.
-	 *
-	 * - `{user} submitted an unban request: {message}` for
-	 *   `channel.unban_request.create`
-	 * - For `channel.unban_request.resolve`:
-	 *   - `{moderator} approved/denied {user}'s unban request[: {reason}]` if
-	 *     there's a moderator attached
-	 *   - `{user}'s unban request was approved/denied/cancelled` otherwise
-	 */
-	public unbanRequest(
-		request: ChannelUnbanRequestCreate | ChannelUnbanRequestResolve,
-		moderator?: Viewer,
-	) {
-		const user = Viewer.fromBasic(request);
-		const name = colorizeName(user);
-
-		if ("status" in request) {
-			if (!moderator) {
-				this.#text = `${name}'s unban request was ${request.status}.`;
-			} else {
-				this.#text = `${colorizeName(moderator)} ${request.status} ${name}'s unban request.`;
-
-				if (request.resolution_text) {
-					this.#text = `${this.#text.slice(0, -1)}: ${request.resolution_text}`;
-				}
-			}
-		} else {
-			this.#text = `${name} submitted an unban request: ${request.text}`;
-		}
-
-		return this;
-	}
-
-	/**
-	 * Sets the text of the system message when a user's timeout is removed.
-	 *
-	 * `{moderator} removed timeout on {user}`
-	 */
-	public untimeout(user: Viewer, moderator: Viewer) {
-		this.#text = `${colorizeName(moderator)} removed timeout on ${colorizeName(user)}.`;
-		return this;
-	}
-
-	/**
-	 * Sets the text of the system message when a user is warned.
-	 *
-	 * `{moderator} warned {user}[: {reason[, ]}]`
-	 */
-	public warn(warning: WarnMetadata, moderator: Viewer) {
-		const user = Viewer.fromBasic(warning);
-		this.#text = `${colorizeName(moderator)} warned ${colorizeName(user)}.`;
-
-		if (warning.reason || warning.chat_rules_cited) {
-			const reasons = [warning.reason, ...(warning.chat_rules_cited ?? [])]
-				.filter((r) => r !== null)
-				.join(", ");
-
-			this.#text = `${this.#text.slice(0, -1)}: ${reasons}`;
-		}
-
-		return this;
-	}
-
-	/**
-	 * Sets the text of the system message when a user acknowledges their
-	 * warning.
-	 *
-	 * `{user} acknowledged their warning`
-	 */
-	public warnAck(user: Viewer) {
-		this.#text = `${colorizeName(user)} acknowledged their warning.`;
+	public setContext(context: SystemMessageContext) {
+		this.context = context;
 		return this;
 	}
 


### PR DESCRIPTION
This is a bit more verbose but avoids the possibility of XSS. `@html` is still used but only for rendering colored names and not on anything that could contain unsanitized html.

Fixes #45.