### PR TITLE
fix(sidebar): invert search logic to update offline streams

### DIFF
--- a/src/lib/components/ChannelList.svelte
+++ b/src/lib/components/ChannelList.svelte
@@ -33,9 +33,9 @@
 					ids: app.channels.map((c) => c.user.id),
 				});
 
-				for (const stream of streams) {
-					const chan = app.channels.find((c) => c.user.id === stream.user_id);
-					chan?.setStream(stream);
+				for (const channel of app.channels) {
+					const stream = streams.find((s) => s.user_id === channel.user.id);
+					channel.setStream(stream ?? null);
 				}
 			},
 			5 * 60 * 1000,


### PR DESCRIPTION
Since the Get Streams endpoint only returns streams for channels that are live, we need to iterate through `app.channels` instead to make sure every stream is updated.