### PR TITLE
refactor(chat): send messages through frontend

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -123,7 +123,6 @@ fn get_handler() -> impl Fn(Invoke) -> bool {
         api::channels::get_followed_channels,
         api::chat::join,
         api::chat::leave,
-        api::chat::send_message,
         api::chat::fetch_global_badges,
         api::moderation::delete_message,
         api::moderation::update_held_message,
@@ -138,6 +137,7 @@ fn get_handler() -> impl Fn(Invoke) -> bool {
         log::log,
         providers::fetch_recent_messages,
         providers::seventv::connect_seventv,
+        providers::seventv::send_presence,
         server::start_server
     ]
 }

--- a/src/lib/channel.svelte.ts
+++ b/src/lib/channel.svelte.ts
@@ -181,7 +181,7 @@ export class Channel {
 				log.info("Message sent");
 				await invoke("send_presence", { channelId: this.user.id });
 			} else {
-				const reason = body.data[0].drop_reason;
+				const reason = body.data[0].drop_reason.message;
 
 				log.warn(`Message dropped: ${reason}`);
 				this.addMessage(sysmsg.setText(reason));


### PR DESCRIPTION
The cost of IPC when sending consecutive messages with `ctrl+enter` was causing massive latency.