### PR TITLE
fix: title bar left padding on linux

### DIFF
--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -66,7 +66,7 @@
 		class={[
 			"text-muted-foreground flex items-center gap-0.5",
 			platform === "macos" && "pl-18",
-			platform === "windows" && "pl-3",
+			["windows", "linux"].includes(platform) && "pl-3",
 		]}
 		data-tauri-drag-region
 	>


### PR DESCRIPTION
This is the only visual thing I noticed that wasn't right. Another thing is that the debug info shows the following:

```
Hyperion v0.1.0
linux x86_64 (Unknown)
```

`Unknown` is probably not very helpful there, but it probably doesn't matter much.