### PR TITLE
refactor(irc): collapse connection loop into single async fn

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1029,18 +1029,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
-name = "enum_dispatch"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,7 +1923,6 @@ version = "0.2.1"
 dependencies = [
  "anyhow",
  "either",
- "enum_dispatch",
  "futures",
  "httparse",
  "mimalloc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,7 +38,6 @@ tauri-plugin-svelte = "3"
 
 anyhow = "1.0.97"
 either = "1.15.0"
-enum_dispatch = "0.3.13"
 futures = "0.3.31"
 httparse = "1.10.1"
 mimalloc = "0.1"

--- a/src-tauri/src/irc/client/event_loop.rs
+++ b/src-tauri/src/irc/client/event_loop.rs
@@ -6,7 +6,6 @@ use tokio::sync::{mpsc, oneshot};
 use super::pool_connection::PoolConnection;
 use crate::irc;
 use crate::irc::ClientConfig;
-use crate::irc::connection::event_loop::ConnectionLoopCommand;
 use crate::irc::connection::{Connection, ConnectionIncomingMessage};
 use crate::irc::message::{JoinMessage, PartMessage, ServerMessage};
 
@@ -163,10 +162,7 @@ impl ClientLoopWorker {
         pool_connection
             .connection
             .connection_loop_tx
-            .send(ConnectionLoopCommand::SendMessage(
-                irc!["JOIN", format!("#{}", channel_login)],
-                None,
-            ))
+            .send((irc!["JOIN", format!("#{}", channel_login)], None))
             .unwrap();
 
         pool_connection.register_sent_message();
@@ -194,10 +190,7 @@ impl ClientLoopWorker {
         pool_connection
             .connection
             .connection_loop_tx
-            .send(ConnectionLoopCommand::SendMessage(
-                irc!["PART", format!("#{}", channel_login)],
-                None,
-            ))
+            .send((irc!["PART", format!("#{}", channel_login)], None))
             .unwrap();
 
         pool_connection.register_sent_message();

--- a/src-tauri/src/irc/connection/event_loop.rs
+++ b/src-tauri/src/irc/connection/event_loop.rs
@@ -1,498 +1,289 @@
 use std::collections::VecDeque;
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 use either::Either;
-use enum_dispatch::enum_dispatch;
 use futures::{SinkExt, StreamExt};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Duration, Instant, interval_at};
-use tokio_tungstenite::tungstenite::Error as WsError;
 
 use super::ConnectionIncomingMessage;
 use crate::irc;
 use crate::irc::message::{IrcMessage, ServerMessage};
-use crate::irc::websocket::{Incoming, Outgoing, WsTransport};
+use crate::irc::websocket::WsTransport;
 use crate::irc::{ClientConfig, Error};
+
+/// Public command type accepted by the connection loop. Only `SendMessage` is
+/// exposed to callers; the loop is otherwise driven by its own internal
+/// timers and the underlying transport.
+type ReplySender = oneshot::Sender<Result<(), Error>>;
+type PendingMessage = (IrcMessage, Option<ReplySender>);
 
 #[derive(Debug)]
 pub(crate) enum ConnectionLoopCommand {
-    SendMessage(IrcMessage, Option<oneshot::Sender<Result<(), Error>>>),
-    TransportInitFinished(Result<(WsTransport, String, String), Error>),
-    SendError(Arc<WsError>),
-    IncomingMessage(Option<Result<IrcMessage, Error>>),
-    SendPing(),
-    CheckPong(),
+    SendMessage(IrcMessage, Option<ReplySender>),
 }
 
-#[enum_dispatch]
-trait ConnectionLoopStateMethods {
-    fn send_message(
-        &mut self,
-        message: IrcMessage,
-        reply_sender: Option<oneshot::Sender<Result<(), Error>>>,
-    );
-    fn on_transport_init_finished(
-        self,
-        init_result: Result<(WsTransport, String, String), Error>,
-    ) -> ConnectionLoopState;
-    fn on_send_error(self, error: Arc<WsError>) -> ConnectionLoopState;
-    fn on_incoming_message(
-        self,
-        maybe_message: Option<Result<IrcMessage, Error>>,
-    ) -> ConnectionLoopState;
-    fn send_ping(&mut self);
-    fn check_pong(self) -> ConnectionLoopState;
-}
-
-#[enum_dispatch(ConnectionLoopStateMethods)]
-enum ConnectionLoopState {
-    Initializing(ConnectionLoopInitializingState),
-    Open(ConnectionLoopOpenState),
-    Closed(ConnectionLoopClosedState),
-}
-
-pub(crate) struct ConnectionLoopWorker {
-    connection_loop_rx: mpsc::UnboundedReceiver<ConnectionLoopCommand>,
-    state: ConnectionLoopState,
-}
+pub(crate) struct ConnectionLoopWorker;
 
 impl ConnectionLoopWorker {
     pub fn spawn(
         config: Arc<ClientConfig>,
         connection_incoming_tx: mpsc::UnboundedSender<ConnectionIncomingMessage>,
-        connection_loop_tx: Weak<mpsc::UnboundedSender<ConnectionLoopCommand>>,
         connection_loop_rx: mpsc::UnboundedReceiver<ConnectionLoopCommand>,
     ) {
-        let worker = ConnectionLoopWorker {
-            connection_loop_rx,
-            state: ConnectionLoopState::Initializing(ConnectionLoopInitializingState {
-                commands_queue: VecDeque::new(),
-                connection_loop_tx: Weak::clone(&connection_loop_tx),
-                connection_incoming_tx,
-            }),
-        };
-
-        tokio::spawn(ConnectionLoopWorker::run_init_task(
-            config,
-            connection_loop_tx,
-        ));
-
-        tokio::spawn(worker.run());
-    }
-
-    async fn run_init_task(
-        config: Arc<ClientConfig>,
-        connection_loop_tx: Weak<mpsc::UnboundedSender<ConnectionLoopCommand>>,
-    ) {
-        let res = try {
-            let login = config.login.clone();
-            let token = config.token.clone();
-
-            let rate_limit_permit = Arc::clone(&config.connection_rate_limiter)
-                .acquire_owned()
-                .await;
-
-            let connect_attempt = WsTransport::new();
-            let timeout = tokio::time::sleep(config.connect_timeout);
-
-            let transport = tokio::select! {
-                t_result = connect_attempt => {
-                    t_result.map_err(Arc::new)
-                        .map_err(Error::Connect)
-                },
-                _ = timeout => {
-                    Err(Error::ConnectTimeout)
-                }
-            }?;
-
-            tokio::spawn(async move {
-                tokio::time::sleep(config.new_connection_every).await;
-                drop(rate_limit_permit);
-            });
-
-            (transport, login, token)
-        };
-
-        if let Some(connection_loop_tx) = connection_loop_tx.upgrade() {
-            connection_loop_tx
-                .send(ConnectionLoopCommand::TransportInitFinished(res))
-                .ok();
-        }
-    }
-
-    async fn run(mut self) {
-        while let Some(command) = self.connection_loop_rx.recv().await {
-            self = self.process_command(command);
-        }
-    }
-
-    fn process_command(mut self, command: ConnectionLoopCommand) -> Self {
-        match command {
-            ConnectionLoopCommand::SendMessage(message, reply_sender) => {
-                self.state.send_message(message, reply_sender);
-            }
-            ConnectionLoopCommand::TransportInitFinished(init_result) => {
-                self.state = self.state.on_transport_init_finished(init_result);
-            }
-            ConnectionLoopCommand::SendError(error) => {
-                self.state = self.state.on_send_error(error);
-            }
-            ConnectionLoopCommand::IncomingMessage(maybe_msg) => {
-                self.state = self.state.on_incoming_message(maybe_msg);
-            }
-            ConnectionLoopCommand::SendPing() => self.state.send_ping(),
-            ConnectionLoopCommand::CheckPong() => {
-                self.state = self.state.check_pong();
-            }
-        };
-        self
+        tokio::spawn(run(config, connection_incoming_tx, connection_loop_rx));
     }
 }
 
-type CommandQueue = VecDeque<(IrcMessage, Option<oneshot::Sender<Result<(), Error>>>)>;
-type MessageReceiver =
-    mpsc::UnboundedReceiver<(IrcMessage, Option<oneshot::Sender<Result<(), Error>>>)>;
-type MessageSender =
-    mpsc::UnboundedSender<(IrcMessage, Option<oneshot::Sender<Result<(), Error>>>)>;
+fn close_with_error(
+    err: Error,
+    pending: VecDeque<PendingMessage>,
+    mut connection_loop_rx: mpsc::UnboundedReceiver<ConnectionLoopCommand>,
+    connection_incoming_tx: &mpsc::UnboundedSender<ConnectionIncomingMessage>,
+) {
+    for (_msg, reply) in pending {
+        if let Some(reply) = reply {
+            reply.send(Err(err.clone())).ok();
+        }
+    }
 
-struct ConnectionLoopInitializingState {
-    commands_queue: CommandQueue,
-    connection_loop_tx: Weak<mpsc::UnboundedSender<ConnectionLoopCommand>>,
+    // Drain anything that's already been queued by senders so they don't hang
+    // waiting on a reply
+    connection_loop_rx.close();
+    while let Ok(ConnectionLoopCommand::SendMessage(_, reply)) = connection_loop_rx.try_recv() {
+        if let Some(reply) = reply {
+            reply.send(Err(err.clone())).ok();
+        }
+    }
+
+    connection_incoming_tx
+        .send(ConnectionIncomingMessage::StateClosed)
+        .ok();
+}
+
+async fn establish_transport(
+    config: Arc<ClientConfig>,
+) -> Result<(WsTransport, String, String), Error> {
+    let login = config.login.clone();
+    let token = config.token.clone();
+
+    let rate_limit_permit = Arc::clone(&config.connection_rate_limiter)
+        .acquire_owned()
+        .await;
+
+    let connect_attempt = WsTransport::new();
+    let timeout = tokio::time::sleep(config.connect_timeout);
+
+    let transport = tokio::select! {
+        t_result = connect_attempt => {
+            t_result.map_err(Arc::new).map_err(Error::Connect)
+        },
+        _ = timeout => {
+            Err(Error::ConnectTimeout)
+        }
+    }?;
+
+    let new_connection_every = config.new_connection_every;
+
+    tokio::spawn(async move {
+        tokio::time::sleep(new_connection_every).await;
+        drop(rate_limit_permit);
+    });
+
+    Ok((transport, login, token))
+}
+
+async fn run(
+    config: Arc<ClientConfig>,
     connection_incoming_tx: mpsc::UnboundedSender<ConnectionIncomingMessage>,
-}
+    mut connection_loop_rx: mpsc::UnboundedReceiver<ConnectionLoopCommand>,
+) {
+    // Connect while buffering any commands from callers
+    let mut pending: VecDeque<PendingMessage> = VecDeque::new();
 
-impl ConnectionLoopInitializingState {
-    fn transition_to_closed(self, err: Error) -> ConnectionLoopState {
-        for (_message, return_sender) in self.commands_queue.into_iter() {
-            if let Some(return_sender) = return_sender {
-                return_sender.send(Err(err.clone())).ok();
-            }
-        }
+    let init_fut = establish_transport(Arc::clone(&config));
+    tokio::pin!(init_fut);
 
-        self.connection_incoming_tx
-            .send(ConnectionIncomingMessage::StateClosed)
-            .ok();
-
-        ConnectionLoopState::Closed(ConnectionLoopClosedState {
-            reason_for_closure: err,
-        })
-    }
-
-    async fn run_incoming_forward_task(
-        mut transport_incoming: Incoming,
-        connection_loop_tx: Weak<mpsc::UnboundedSender<ConnectionLoopCommand>>,
-        mut shutdown_notify: oneshot::Receiver<()>,
-    ) {
-        loop {
-            tokio::select! {
-                _ = &mut shutdown_notify => {
-                    break;
-                }
-                incoming_message = transport_incoming.next() => {
-                    let do_exit = matches!(incoming_message, None | Some(Err(_)));
-
-                    let incoming_message = incoming_message.map(|x| x.map_err(|e| match e {
-                        Either::Left(e) => Error::Incoming(Arc::new(e)),
-                        Either::Right(e) => Error::IrcParse(e)
-                    }));
-
-                    if let Some(connection_loop_tx) = connection_loop_tx.upgrade() {
-                        connection_loop_tx.send(ConnectionLoopCommand::IncomingMessage(incoming_message)).ok();
-                    } else {
-                        break;
+    let init_result = loop {
+        tokio::select! {
+            res = &mut init_fut => break res,
+            cmd = connection_loop_rx.recv() => {
+                match cmd {
+                    Some(ConnectionLoopCommand::SendMessage(msg, reply)) => {
+                        pending.push_back((msg, reply));
                     }
-
-                    if do_exit {
-                        break;
+                    None => {
+                        // Parent dropped before connect finished. Bail without
+                        // emitting a state-closed (no consumer cares).
+                        return;
                     }
                 }
             }
         }
-    }
+    };
 
-    async fn run_outgoing_forward_task(
-        mut transport_outgoing: Outgoing,
-        mut messages_rx: MessageReceiver,
-        connection_loop_tx: Weak<mpsc::UnboundedSender<ConnectionLoopCommand>>,
-    ) {
-        while let Some((message, reply_sender)) = messages_rx.recv().await {
-            let res = transport_outgoing.send(message).await.map_err(Arc::new);
-
-            if let Err(ref err) = res
-                && let Some(connection_loop_tx) = connection_loop_tx.upgrade()
-            {
-                connection_loop_tx
-                    .send(ConnectionLoopCommand::SendError(Arc::clone(err)))
-                    .ok();
-            }
-
-            if let Some(reply_sender) = reply_sender {
-                reply_sender.send(res.map_err(Error::Outgoing)).ok();
-            }
+    let (transport, login, token) = match init_result {
+        Ok(t) => t,
+        Err(err) => {
+            close_with_error(err, pending, connection_loop_rx, &connection_incoming_tx);
+            return;
         }
-    }
+    };
 
-    async fn run_ping_task(
-        connection_loop_tx: Weak<mpsc::UnboundedSender<ConnectionLoopCommand>>,
-        mut shutdown_notify: oneshot::Receiver<()>,
-    ) {
-        let ping_every = Duration::from_secs(30);
-        let check_pong_after = Duration::from_secs(5);
+    let (mut transport_incoming, mut transport_outgoing) = transport.split();
 
-        let mut send_ping_interval = interval_at(Instant::now() + ping_every, ping_every);
-        let mut check_pong_interval =
-            interval_at(Instant::now() + ping_every + check_pong_after, ping_every);
+    // Send handshake + any buffered commands
+    // Helper to push a message out; close on transport error
+    macro_rules! send_or_close {
+        ($msg:expr, $reply:expr) => {{
+            let res = transport_outgoing.send($msg).await.map_err(Arc::new);
+            let reply: Option<ReplySender> = $reply;
 
-        loop {
-            tokio::select! {
-                _ = &mut shutdown_notify => {
-                    break;
-                },
-                _ = send_ping_interval.tick() => {
-                    if let Some(connection_loop_tx) = connection_loop_tx.upgrade() {
-                        connection_loop_tx.send(ConnectionLoopCommand::SendPing()).ok();
-                    } else {
-                        break;
+            match res {
+                Ok(()) => {
+                    if let Some(reply) = reply {
+                        reply.send(Ok(())).ok();
                     }
+
+                    Ok(())
                 }
-                _ = check_pong_interval.tick() => {
-                    if let Some(connection_loop_tx) = connection_loop_tx.upgrade() {
-                        connection_loop_tx.send(ConnectionLoopCommand::CheckPong()).ok();
-                    } else {
-                        break;
+                Err(err) => {
+                    let outgoing_err = Error::Outgoing(Arc::clone(&err));
+
+                    if let Some(reply) = reply {
+                        reply.send(Err(outgoing_err.clone())).ok();
                     }
+
+                    Err(outgoing_err)
                 }
             }
-        }
-    }
-}
-
-impl ConnectionLoopStateMethods for ConnectionLoopInitializingState {
-    fn send_message(
-        &mut self,
-        message: IrcMessage,
-        reply_sender: Option<oneshot::Sender<Result<(), Error>>>,
-    ) {
-        self.commands_queue.push_back((message, reply_sender));
+        }};
     }
 
-    fn on_transport_init_finished(
-        self,
-        init_result: Result<(WsTransport, String, String), Error>,
-    ) -> ConnectionLoopState {
-        match init_result {
-            Ok((transport, login, token)) => {
-                let (transport_incoming, transport_outgoing) = transport.split();
+    let handshake = [
+        irc!["CAP", "REQ", "twitch.tv/tags twitch.tv/commands"],
+        irc!["PASS", format!("oauth:{}", token)],
+        irc!["NICK", login],
+    ];
 
-                let (kill_incoming_loop_tx, kill_incoming_loop_rx) = oneshot::channel();
-                tokio::spawn(ConnectionLoopInitializingState::run_incoming_forward_task(
-                    transport_incoming,
-                    Weak::clone(&self.connection_loop_tx),
-                    kill_incoming_loop_rx,
-                ));
-
-                let (outgoing_messages_tx, outgoing_messages_rx) = mpsc::unbounded_channel();
-                tokio::spawn(ConnectionLoopInitializingState::run_outgoing_forward_task(
-                    transport_outgoing,
-                    outgoing_messages_rx,
-                    Weak::clone(&self.connection_loop_tx),
-                ));
-
-                let (kill_pinger_tx, kill_pinger_rx) = oneshot::channel();
-                tokio::spawn(ConnectionLoopInitializingState::run_ping_task(
-                    Weak::clone(&self.connection_loop_tx),
-                    kill_pinger_rx,
-                ));
-
-                let mut new_state = ConnectionLoopState::Open(ConnectionLoopOpenState {
-                    connection_incoming_tx: self.connection_incoming_tx,
-                    outgoing_messages_tx,
-                    pong_received: false,
-                    kill_incoming_loop_tx: Some(kill_incoming_loop_tx),
-                    kill_pinger_tx: Some(kill_pinger_tx),
-                });
-
-                new_state.send_message(
-                    irc!["CAP", "REQ", "twitch.tv/tags twitch.tv/commands"],
-                    None,
-                );
-
-                new_state.send_message(irc!["PASS", format!("oauth:{}", token)], None);
-                new_state.send_message(irc!["NICK", login], None);
-
-                for (message, return_sender) in self.commands_queue.into_iter() {
-                    new_state.send_message(message, return_sender);
-                }
-
-                new_state
-            }
-            Err(init_error) => self.transition_to_closed(init_error),
+    for msg in handshake {
+        if let Err(err) = send_or_close!(msg, None) {
+            close_with_error(err, pending, connection_loop_rx, &connection_incoming_tx);
+            return;
         }
     }
 
-    fn on_send_error(self, error: Arc<WsError>) -> ConnectionLoopState {
-        self.transition_to_closed(Error::Outgoing(error))
+    while let Some((msg, reply)) = pending.pop_front() {
+        if let Err(err) = send_or_close!(msg, reply) {
+            close_with_error(err, pending, connection_loop_rx, &connection_incoming_tx);
+            return;
+        }
     }
 
-    fn on_incoming_message(
-        self,
-        _maybe_message: Option<Result<IrcMessage, Error>>,
-    ) -> ConnectionLoopState {
-        unreachable!("messages cannot come in while initializing")
-    }
+    // Main pump
+    let ping_every = Duration::from_secs(30);
+    let check_pong_after = Duration::from_secs(5);
 
-    fn send_ping(&mut self) {
-        unreachable!("pinger should not run while initializing")
-    }
+    let mut send_ping_interval = interval_at(Instant::now() + ping_every, ping_every);
+    let mut check_pong_interval =
+        interval_at(Instant::now() + ping_every + check_pong_after, ping_every);
 
-    fn check_pong(self) -> ConnectionLoopState {
-        unreachable!("pinger should not run while initializing")
-    }
-}
+    let mut pong_received = false;
 
-struct ConnectionLoopOpenState {
-    connection_incoming_tx: mpsc::UnboundedSender<ConnectionIncomingMessage>,
-    outgoing_messages_tx: MessageSender,
-    pong_received: bool,
-    kill_incoming_loop_tx: Option<oneshot::Sender<()>>,
-    kill_pinger_tx: Option<oneshot::Sender<()>>,
-}
-
-impl ConnectionLoopOpenState {
-    fn transition_to_closed(self, cause: Error) -> ConnectionLoopState {
-        self.connection_incoming_tx
-            .send(ConnectionIncomingMessage::StateClosed)
-            .ok();
-
-        ConnectionLoopState::Closed(ConnectionLoopClosedState {
-            reason_for_closure: cause,
-        })
-    }
-}
-
-impl Drop for ConnectionLoopOpenState {
-    fn drop(&mut self) {
-        self.kill_incoming_loop_tx.take().unwrap().send(()).ok();
-        self.kill_pinger_tx.take().unwrap().send(()).ok();
-    }
-}
-
-impl ConnectionLoopStateMethods for ConnectionLoopOpenState {
-    fn send_message(
-        &mut self,
-        message: IrcMessage,
-        reply_sender: Option<oneshot::Sender<Result<(), Error>>>,
-    ) {
-        self.outgoing_messages_tx.send((message, reply_sender)).ok();
-    }
-
-    fn on_transport_init_finished(
-        self,
-        _: Result<(WsTransport, String, String), Error>,
-    ) -> ConnectionLoopState {
-        unreachable!("transport init cannot finish more than once")
-    }
-
-    fn on_send_error(self, error: Arc<WsError>) -> ConnectionLoopState {
-        self.transition_to_closed(Error::Outgoing(error))
-    }
-
-    fn on_incoming_message(
-        mut self,
-        maybe_message: Option<Result<IrcMessage, Error>>,
-    ) -> ConnectionLoopState {
-        match maybe_message {
-            None => self.transition_to_closed(Error::RemoteUnexpectedlyClosedConnection),
-            Some(Err(error)) => self.transition_to_closed(error),
-            Some(Ok(irc_message)) => {
-                let server_message = ServerMessage::try_from(irc_message);
-
-                match server_message {
-                    Ok(server_message) => {
-                        let should_close =
-                            matches!(&server_message, ServerMessage::Reconnect(_));
-
-                        match &server_message {
-                            ServerMessage::Ping(_) => {
-                                self.send_message(irc!["PONG", "tmi.twitch.tv"], None);
-                            }
-                            ServerMessage::Pong(_) => {
-                                self.pong_received = true;
-                            }
-                            _ => {}
-                        }
-
-                        self.connection_incoming_tx
-                            .send(ConnectionIncomingMessage::IncomingMessage(Box::new(
-                                server_message,
-                            )))
-                            .ok();
-
-                        if should_close {
-                            return self.transition_to_closed(Error::ReconnectCmd);
+    let close_reason: Error = loop {
+        tokio::select! {
+            cmd = connection_loop_rx.recv() => {
+                match cmd {
+                    Some(ConnectionLoopCommand::SendMessage(msg, reply)) => {
+                        if let Err(err) = send_or_close!(msg, reply) {
+                            break err;
                         }
                     }
-                    Err(parse_error) => {
-                        self.connection_incoming_tx
-                            .send(ConnectionIncomingMessage::IncomingMessage(Box::new(
-                                ServerMessage::new_generic(IrcMessage::from(parse_error)),
-                            )))
-                            .ok();
+                    None => {
+                        // Parent dropped; quit cleanly without emitting a
+                        // state-closed (consumer is gone)
+                        return;
                     }
                 }
+            }
+            incoming = transport_incoming.next() => {
+                match incoming {
+                    None => break Error::RemoteUnexpectedlyClosedConnection,
+                    Some(Err(e)) => {
+                        let err = match e {
+                            Either::Left(e) => Error::Incoming(Arc::new(e)),
+                            Either::Right(e) => Error::IrcParse(e),
+                        };
+                        break err;
+                    }
+                    Some(Ok(irc_message)) => {
+                        match ServerMessage::try_from(irc_message) {
+                            Ok(server_message) => {
+                                let should_close =
+                                    matches!(&server_message, ServerMessage::Reconnect(_));
 
-                ConnectionLoopState::Open(self)
+                                match &server_message {
+                                    ServerMessage::Ping(_) => {
+                                        if let Err(err) = send_or_close!(
+                                            irc!["PONG", "tmi.twitch.tv"],
+                                            None
+                                        ) {
+                                            // Forward the ping to consumers before exiting
+                                            connection_incoming_tx
+                                                .send(ConnectionIncomingMessage::IncomingMessage(
+                                                    Box::new(server_message),
+                                                ))
+                                                .ok();
+
+                                            break err;
+                                        }
+                                    }
+                                    ServerMessage::Pong(_) => {
+                                        pong_received = true;
+                                    }
+                                    _ => {}
+                                }
+
+                                connection_incoming_tx
+                                    .send(ConnectionIncomingMessage::IncomingMessage(Box::new(
+                                        server_message,
+                                    )))
+                                    .ok();
+
+                                if should_close {
+                                    break Error::ReconnectCmd;
+                                }
+                            }
+                            Err(parse_error) => {
+                                connection_incoming_tx
+                                    .send(ConnectionIncomingMessage::IncomingMessage(Box::new(
+                                        ServerMessage::new_generic(IrcMessage::from(parse_error)),
+                                    )))
+                                    .ok();
+                            }
+                        }
+                    }
+                }
+            }
+            _ = send_ping_interval.tick() => {
+                pong_received = false;
+
+                if let Err(err) = send_or_close!(irc!["PING", "tmi.twitch.tv"], None) {
+                    break err;
+                }
+            }
+            _ = check_pong_interval.tick() => {
+                if !pong_received {
+                    break Error::PingTimeout;
+                }
             }
         }
-    }
+    };
 
-    fn send_ping(&mut self) {
-        self.pong_received = false;
-        self.send_message(irc!["PING", "tmi.twitch.tv"], None);
-    }
-
-    fn check_pong(self) -> ConnectionLoopState {
-        if !self.pong_received {
-            self.transition_to_closed(Error::PingTimeout)
-        } else {
-            ConnectionLoopState::Open(self)
-        }
-    }
-}
-
-struct ConnectionLoopClosedState {
-    reason_for_closure: Error,
-}
-
-impl ConnectionLoopStateMethods for ConnectionLoopClosedState {
-    fn send_message(
-        &mut self,
-        _: IrcMessage,
-        reply_sender: Option<oneshot::Sender<Result<(), Error>>>,
-    ) {
-        if let Some(reply_sender) = reply_sender {
-            reply_sender.send(Err(self.reason_for_closure.clone())).ok();
-        }
-    }
-
-    fn on_transport_init_finished(
-        self,
-        _: Result<(WsTransport, String, String), Error>,
-    ) -> ConnectionLoopState {
-        ConnectionLoopState::Closed(self)
-    }
-
-    fn on_send_error(self, _error: Arc<WsError>) -> ConnectionLoopState {
-        ConnectionLoopState::Closed(self)
-    }
-
-    fn on_incoming_message(self, _: Option<Result<IrcMessage, Error>>) -> ConnectionLoopState {
-        ConnectionLoopState::Closed(self)
-    }
-
-    fn send_ping(&mut self) {}
-
-    fn check_pong(self) -> ConnectionLoopState {
-        ConnectionLoopState::Closed(self)
-    }
+    close_with_error(
+        close_reason,
+        VecDeque::new(),
+        connection_loop_rx,
+        &connection_incoming_tx,
+    );
 }

--- a/src-tauri/src/irc/connection/event_loop.rs
+++ b/src-tauri/src/irc/connection/event_loop.rs
@@ -35,7 +35,7 @@ impl ConnectionLoopWorker {
     }
 }
 
-fn close_with_error(
+async fn close_with_error(
     err: Error,
     pending: VecDeque<PendingMessage>,
     mut connection_loop_rx: mpsc::UnboundedReceiver<ConnectionLoopCommand>,
@@ -47,18 +47,18 @@ fn close_with_error(
         }
     }
 
-    // Drain anything that's already been queued by senders so they don't hang
-    // waiting on a reply
-    connection_loop_rx.close();
-    while let Ok(ConnectionLoopCommand::SendMessage(_, reply)) = connection_loop_rx.try_recv() {
+    connection_incoming_tx
+        .send(ConnectionIncomingMessage::StateClosed)
+        .ok();
+
+    // Keep accepting commands until all senders are dropped so callers that
+    // race a transport error with `send(...).unwrap()` don't panic. Reply with
+    // the close error when a reply channel was provided; otherwise drop.
+    while let Some(ConnectionLoopCommand::SendMessage(_, reply)) = connection_loop_rx.recv().await {
         if let Some(reply) = reply {
             reply.send(Err(err.clone())).ok();
         }
     }
-
-    connection_incoming_tx
-        .send(ConnectionIncomingMessage::StateClosed)
-        .ok();
 }
 
 async fn establish_transport(
@@ -125,7 +125,7 @@ async fn run(
     let (transport, login, token) = match init_result {
         Ok(t) => t,
         Err(err) => {
-            close_with_error(err, pending, connection_loop_rx, &connection_incoming_tx);
+            close_with_error(err, pending, connection_loop_rx, &connection_incoming_tx).await;
             return;
         }
     };
@@ -168,14 +168,14 @@ async fn run(
 
     for msg in handshake {
         if let Err(err) = send_or_close!(msg, None) {
-            close_with_error(err, pending, connection_loop_rx, &connection_incoming_tx);
+            close_with_error(err, pending, connection_loop_rx, &connection_incoming_tx).await;
             return;
         }
     }
 
     while let Some((msg, reply)) = pending.pop_front() {
         if let Err(err) = send_or_close!(msg, reply) {
-            close_with_error(err, pending, connection_loop_rx, &connection_incoming_tx);
+            close_with_error(err, pending, connection_loop_rx, &connection_incoming_tx).await;
             return;
         }
     }
@@ -189,9 +189,24 @@ async fn run(
         interval_at(Instant::now() + ping_every + check_pong_after, ping_every);
 
     let mut pong_received = false;
+    let mut awaiting_pong = false;
 
     let close_reason: Error = loop {
         tokio::select! {
+            biased;
+            _ = send_ping_interval.tick() => {
+                pong_received = false;
+                awaiting_pong = true;
+
+                if let Err(err) = send_or_close!(irc!["PING", "tmi.twitch.tv"], None) {
+                    break err;
+                }
+            }
+            _ = check_pong_interval.tick() => {
+                if awaiting_pong && !pong_received {
+                    break Error::PingTimeout;
+                }
+            }
             cmd = connection_loop_rx.recv() => {
                 match cmd {
                     Some(ConnectionLoopCommand::SendMessage(msg, reply)) => {
@@ -265,18 +280,6 @@ async fn run(
                     }
                 }
             }
-            _ = send_ping_interval.tick() => {
-                pong_received = false;
-
-                if let Err(err) = send_or_close!(irc!["PING", "tmi.twitch.tv"], None) {
-                    break err;
-                }
-            }
-            _ = check_pong_interval.tick() => {
-                if !pong_received {
-                    break Error::PingTimeout;
-                }
-            }
         }
     };
 
@@ -285,5 +288,6 @@ async fn run(
         VecDeque::new(),
         connection_loop_rx,
         &connection_incoming_tx,
-    );
+    )
+    .await;
 }

--- a/src-tauri/src/irc/connection/event_loop.rs
+++ b/src-tauri/src/irc/connection/event_loop.rs
@@ -12,16 +12,8 @@ use crate::irc::message::{IrcMessage, ServerMessage};
 use crate::irc::websocket::WsTransport;
 use crate::irc::{ClientConfig, Error};
 
-/// Public command type accepted by the connection loop. Only `SendMessage` is
-/// exposed to callers; the loop is otherwise driven by its own internal
-/// timers and the underlying transport.
-type ReplySender = oneshot::Sender<Result<(), Error>>;
-type PendingMessage = (IrcMessage, Option<ReplySender>);
-
-#[derive(Debug)]
-pub(crate) enum ConnectionLoopCommand {
-    SendMessage(IrcMessage, Option<ReplySender>),
-}
+pub(crate) type ReplySender = oneshot::Sender<Result<(), Error>>;
+pub(crate) type PendingMessage = (IrcMessage, Option<ReplySender>);
 
 pub(crate) struct ConnectionLoopWorker;
 
@@ -29,7 +21,7 @@ impl ConnectionLoopWorker {
     pub fn spawn(
         config: Arc<ClientConfig>,
         connection_incoming_tx: mpsc::UnboundedSender<ConnectionIncomingMessage>,
-        connection_loop_rx: mpsc::UnboundedReceiver<ConnectionLoopCommand>,
+        connection_loop_rx: mpsc::UnboundedReceiver<PendingMessage>,
     ) {
         tokio::spawn(run(config, connection_incoming_tx, connection_loop_rx));
     }
@@ -38,7 +30,7 @@ impl ConnectionLoopWorker {
 async fn close_with_error(
     err: Error,
     pending: VecDeque<PendingMessage>,
-    mut connection_loop_rx: mpsc::UnboundedReceiver<ConnectionLoopCommand>,
+    mut connection_loop_rx: mpsc::UnboundedReceiver<PendingMessage>,
     connection_incoming_tx: &mpsc::UnboundedSender<ConnectionIncomingMessage>,
 ) {
     for (_msg, reply) in pending {
@@ -54,7 +46,7 @@ async fn close_with_error(
     // Keep accepting commands until all senders are dropped so callers that
     // race a transport error with `send(...).unwrap()` don't panic. Reply with
     // the close error when a reply channel was provided; otherwise drop.
-    while let Some(ConnectionLoopCommand::SendMessage(_, reply)) = connection_loop_rx.recv().await {
+    while let Some((_, reply)) = connection_loop_rx.recv().await {
         if let Some(reply) = reply {
             reply.send(Err(err.clone())).ok();
         }
@@ -96,7 +88,7 @@ async fn establish_transport(
 async fn run(
     config: Arc<ClientConfig>,
     connection_incoming_tx: mpsc::UnboundedSender<ConnectionIncomingMessage>,
-    mut connection_loop_rx: mpsc::UnboundedReceiver<ConnectionLoopCommand>,
+    mut connection_loop_rx: mpsc::UnboundedReceiver<PendingMessage>,
 ) {
     // Connect while buffering any commands from callers
     let mut pending: VecDeque<PendingMessage> = VecDeque::new();
@@ -109,7 +101,7 @@ async fn run(
             res = &mut init_fut => break res,
             cmd = connection_loop_rx.recv() => {
                 match cmd {
-                    Some(ConnectionLoopCommand::SendMessage(msg, reply)) => {
+                    Some((msg, reply)) => {
                         pending.push_back((msg, reply));
                     }
                     None => {
@@ -209,7 +201,7 @@ async fn run(
             }
             cmd = connection_loop_rx.recv() => {
                 match cmd {
-                    Some(ConnectionLoopCommand::SendMessage(msg, reply)) => {
+                    Some((msg, reply)) => {
                         if let Err(err) = send_or_close!(msg, reply) {
                             break err;
                         }

--- a/src-tauri/src/irc/connection/mod.rs
+++ b/src-tauri/src/irc/connection/mod.rs
@@ -29,12 +29,7 @@ impl Connection {
         let (connection_incoming_tx, connection_incoming_rx) = mpsc::unbounded_channel();
         let connection_loop_tx = Arc::new(connection_loop_tx);
 
-        ConnectionLoopWorker::spawn(
-            config,
-            connection_incoming_tx,
-            Arc::downgrade(&connection_loop_tx),
-            connection_loop_rx,
-        );
+        ConnectionLoopWorker::spawn(config, connection_incoming_tx, connection_loop_rx);
 
         (connection_incoming_rx, Connection { connection_loop_tx })
     }

--- a/src-tauri/src/irc/connection/mod.rs
+++ b/src-tauri/src/irc/connection/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use super::config::ClientConfig;
-use super::connection::event_loop::{ConnectionLoopCommand, ConnectionLoopWorker};
+use super::connection::event_loop::{ConnectionLoopWorker, PendingMessage};
 use super::message::commands::ServerMessage;
 
 #[derive(Debug)]
@@ -15,7 +15,7 @@ pub enum ConnectionIncomingMessage {
 }
 
 pub(crate) struct Connection {
-    pub connection_loop_tx: Arc<mpsc::UnboundedSender<ConnectionLoopCommand>>,
+    pub connection_loop_tx: Arc<mpsc::UnboundedSender<PendingMessage>>,
 }
 
 impl Connection {


### PR DESCRIPTION
Replaces the IRC connection state machine with a linear `async fn run()` driven by `tokio::select!`. The new loop establishes the websocket, sends the handshake, then pumps incoming transport messages, outgoing commands, a periodic ping, and a pong-timeout check until the transport closes or the parent drops the command sender.

Assisted by Claude.