### PR TITLE
refactor(irc): select directly over connection receivers

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1949,6 +1949,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite",
  "tracing",
  "tracing-appender",
@@ -5410,6 +5411,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,7 @@ sysinfo = "0.37.2"
 thiserror = "2.0.12"
 time = { version = "0.3", features = ["formatting", "local-offset"] }
 tokio = { version = "1.44.2", features = ["macros"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-tungstenite = { version = "0.26.2", features = ["rustls-tls-native-roots"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/src-tauri/src/irc/client/event_loop.rs
+++ b/src-tauri/src/irc/client/event_loop.rs
@@ -1,7 +1,10 @@
 use std::collections::VecDeque;
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 use tokio::sync::{mpsc, oneshot};
+use tokio_stream::StreamExt;
+use tokio_stream::StreamMap;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use super::pool_connection::PoolConnection;
 use crate::irc;
@@ -20,10 +23,6 @@ pub(crate) enum ClientLoopCommand {
     Part {
         channel_login: String,
     },
-    IncomingMessage {
-        source_connection_id: usize,
-        message: Box<ConnectionIncomingMessage>,
-    },
 }
 
 pub(crate) struct ClientLoopWorker {
@@ -32,14 +31,14 @@ pub(crate) struct ClientLoopWorker {
     current_whisper_connection_id: Option<usize>,
     client_loop_rx: mpsc::UnboundedReceiver<ClientLoopCommand>,
     connections: VecDeque<PoolConnection>,
-    client_loop_tx: Weak<mpsc::UnboundedSender<ClientLoopCommand>>,
+    connection_incoming:
+        StreamMap<usize, UnboundedReceiverStream<ConnectionIncomingMessage>>,
     client_incoming_messages_tx: mpsc::UnboundedSender<ServerMessage>,
 }
 
 impl ClientLoopWorker {
     pub fn spawn(
         config: Arc<ClientConfig>,
-        client_loop_tx: Weak<mpsc::UnboundedSender<ClientLoopCommand>>,
         client_loop_rx: mpsc::UnboundedReceiver<ClientLoopCommand>,
         client_incoming_messages_tx: mpsc::UnboundedSender<ServerMessage>,
     ) {
@@ -49,7 +48,7 @@ impl ClientLoopWorker {
             current_whisper_connection_id: None,
             client_loop_rx,
             connections: VecDeque::new(),
-            client_loop_tx,
+            connection_incoming: StreamMap::new(),
             client_incoming_messages_tx,
         };
 
@@ -57,8 +56,16 @@ impl ClientLoopWorker {
     }
 
     async fn run(mut self) {
-        while let Some(command) = self.client_loop_rx.recv().await {
-            self.process_command(command);
+        loop {
+            tokio::select! {
+                command = self.client_loop_rx.recv() => {
+                    let Some(command) = command else { break };
+                    self.process_command(command);
+                }
+                Some((source_connection_id, message)) = self.connection_incoming.next() => {
+                    self.on_incoming_message(source_connection_id, message);
+                }
+            }
         }
     }
 
@@ -74,10 +81,6 @@ impl ClientLoopWorker {
             }
             ClientLoopCommand::Join { channel_login } => self.join(channel_login),
             ClientLoopCommand::Part { channel_login } => self.part(channel_login),
-            ClientLoopCommand::IncomingMessage {
-                source_connection_id,
-                message,
-            } => self.on_incoming_message(source_connection_id, *message),
         }
     }
 
@@ -88,54 +91,13 @@ impl ClientLoopWorker {
 
         let (connection_incoming_messages_rx, connection) =
             Connection::new(Arc::clone(&self.config));
-        let (tx_kill_incoming, rx_kill_incoming) = oneshot::channel();
 
-        let pool_conn = PoolConnection::new(
-            Arc::clone(&self.config),
+        self.connection_incoming.insert(
             connection_id,
-            connection,
-            tx_kill_incoming,
+            UnboundedReceiverStream::new(connection_incoming_messages_rx),
         );
 
-        tokio::spawn(ClientLoopWorker::run_incoming_forward_task(
-            connection_incoming_messages_rx,
-            connection_id,
-            self.client_loop_tx.clone(),
-            rx_kill_incoming,
-        ));
-
-        pool_conn
-    }
-
-    async fn run_incoming_forward_task(
-        mut connection_incoming_messages_rx: mpsc::UnboundedReceiver<ConnectionIncomingMessage>,
-        connection_id: usize,
-        client_loop_tx: Weak<mpsc::UnboundedSender<ClientLoopCommand>>,
-        mut rx_kill_incoming: oneshot::Receiver<()>,
-    ) {
-        loop {
-            tokio::select! {
-                _ = &mut rx_kill_incoming => {
-                    break;
-                }
-                incoming_message = connection_incoming_messages_rx.recv() => {
-                    let Some(incoming_message) = incoming_message else {
-                        break;
-                    };
-
-                    let Some(client_loop_tx) = client_loop_tx.upgrade() else {
-                        break;
-                    };
-
-                    if client_loop_tx.send(ClientLoopCommand::IncomingMessage {
-                        source_connection_id: connection_id,
-                        message: Box::new(incoming_message)
-                    }).is_err() {
-                        break;
-                    }
-                }
-            }
-        }
+        PoolConnection::new(Arc::clone(&self.config), connection_id, connection)
     }
 
     fn join(&mut self, channel_login: String) {
@@ -250,6 +212,8 @@ impl ClientLoopWorker {
                     .position(|c| c.id == source_connection_id)
                     .and_then(|pos| self.connections.remove(pos))
                     .unwrap();
+
+                self.connection_incoming.remove(&source_connection_id);
 
                 for channel in pool_connection.wanted_channels.drain() {
                     self.join(channel);

--- a/src-tauri/src/irc/client/mod.rs
+++ b/src-tauri/src/irc/client/mod.rs
@@ -22,12 +22,7 @@ impl IrcClient {
         let client_loop_tx = Arc::new(client_loop_tx);
         let (client_incoming_messages_tx, client_incoming_messages_rx) = mpsc::unbounded_channel();
 
-        ClientLoopWorker::spawn(
-            config,
-            Arc::downgrade(&client_loop_tx),
-            client_loop_rx,
-            client_incoming_messages_tx,
-        );
+        ClientLoopWorker::spawn(config, client_loop_rx, client_incoming_messages_tx);
 
         (client_incoming_messages_rx, Self { client_loop_tx })
     }

--- a/src-tauri/src/irc/client/pool_connection.rs
+++ b/src-tauri/src/irc/client/pool_connection.rs
@@ -2,14 +2,11 @@ use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Instant;
 
-use tokio::sync::oneshot;
-
 use crate::irc::ClientConfig;
 use crate::irc::connection::Connection;
 
 pub(crate) struct PoolConnection {
     config: Arc<ClientConfig>,
-    tx_kill_incoming: Option<oneshot::Sender<()>>,
     pub id: usize,
     pub connection: Arc<Connection>,
     pub wanted_channels: HashSet<String>,
@@ -18,12 +15,7 @@ pub(crate) struct PoolConnection {
 }
 
 impl PoolConnection {
-    pub fn new(
-        config: Arc<ClientConfig>,
-        id: usize,
-        connection: Connection,
-        tx_kill_incoming: oneshot::Sender<()>,
-    ) -> PoolConnection {
+    pub fn new(config: Arc<ClientConfig>, id: usize, connection: Connection) -> PoolConnection {
         let message_send_times_max_entries = config.max_waiting_messages_per_connection * 2;
 
         PoolConnection {
@@ -33,7 +25,6 @@ impl PoolConnection {
             wanted_channels: HashSet::new(),
             server_channels: HashSet::new(),
             message_send_times: VecDeque::with_capacity(message_send_times_max_entries),
-            tx_kill_incoming: Some(tx_kill_incoming),
         }
     }
 
@@ -50,11 +41,5 @@ impl PoolConnection {
     pub fn channels_limit_not_reached(&self) -> bool {
         let configured_limit = self.config.max_channels_per_connection;
         self.wanted_channels.len() < configured_limit
-    }
-}
-
-impl Drop for PoolConnection {
-    fn drop(&mut self) {
-        self.tx_kill_incoming.take().unwrap().send(()).ok();
     }
 }


### PR DESCRIPTION
Replaces the per-connection forwarding task that repackaged `ConnectionIncomingMessage` into `ClientLoopCommand::IncomingMessage` with a `StreamMap` of `UnboundedReceiverStream` keyed by connection id, multiplexed into the client loop's main `select!`.

This removes the `Weak<Sender>` indirection used to break the forward-task <-> client-channel cycle, the `tx_kill_incoming` oneshot on `PoolConnection`, and the `IncomingMessage` command variant.

Assisted by Claude.