### PR TITLE
refactor: extract shared ws subscription client state

### DIFF
--- a/src-tauri/src/eventsub/client.rs
+++ b/src-tauri/src/eventsub/client.rs
@@ -332,9 +332,15 @@ impl EventSubClient {
                     payload.subscription.id
                 );
 
-                self.subscriptions
-                    .remove_raw(&payload.subscription.kind.to_string())
-                    .await;
+                let id = &payload.subscription.id;
+                if self
+                    .subscriptions
+                    .remove_by(|sub| sub.id == *id)
+                    .await
+                    .is_none()
+                {
+                    tracing::warn!("Revoked subscription {id} not found in store");
+                }
             }
             Ws::Keepalive => (),
         }

--- a/src-tauri/src/eventsub/client.rs
+++ b/src-tauri/src/eventsub/client.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -9,7 +8,7 @@ use serde::de::{DeserializeOwned, Error as DeError};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
 use tokio::net::TcpStream;
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
@@ -21,6 +20,7 @@ use twitch_api::twitch_oauth2::{TwitchToken, UserToken};
 use crate::HTTP;
 use crate::api::Response;
 use crate::error::Error;
+use crate::ws::{ConnectionState, SubscriptionStore};
 
 #[cfg(local)]
 const TWITCH_EVENTSUB_WS_URI: &str = "ws://127.0.0.1:8080/ws";
@@ -132,10 +132,9 @@ impl<'de> Deserialize<'de> for WebSocketMessage {
 pub struct EventSubClient {
     helix: Arc<HelixClient<'static, reqwest::Client>>,
     pub token: Arc<UserToken>,
-    session_id: Mutex<Option<String>>,
-    pub subscriptions: Mutex<HashMap<String, Subscription>>,
+    state: ConnectionState,
+    pub subscriptions: SubscriptionStore<Subscription>,
     sender: mpsc::UnboundedSender<NotificationPayload>,
-    connected: AtomicBool,
     reconnecting: AtomicBool,
 }
 
@@ -151,10 +150,9 @@ impl EventSubClient {
         let client = Self {
             helix,
             token,
-            session_id: Mutex::new(None),
-            subscriptions: Mutex::new(HashMap::new()),
+            state: ConnectionState::new(),
+            subscriptions: SubscriptionStore::new(),
             sender,
-            connected: AtomicBool::default(),
             reconnecting: AtomicBool::default(),
         };
 
@@ -171,12 +169,12 @@ impl EventSubClient {
         })?;
 
         tracing::info!("Connected to EventSub");
-        self.set_connected(true);
+        self.state.set_connected(true);
 
         let result = self.process_stream(stream).await;
 
-        self.set_connected(false);
-        *self.session_id.lock().await = None;
+        self.state.set_connected(false);
+        self.state.set_session_id(None).await;
 
         result
     }
@@ -262,7 +260,7 @@ impl EventSubClient {
         match msg {
             Ws::Welcome(payload) => {
                 tracing::debug!("Set EventSub session id to {}", payload.session.id);
-                *self.session_id.lock().await = Some(payload.session.id);
+                self.state.set_session_id(Some(payload.session.id)).await;
 
                 let was_reconnecting = self.reconnecting.swap(false, Ordering::Relaxed);
 
@@ -271,20 +269,19 @@ impl EventSubClient {
                 } else {
                     tracing::info!("Initial connection to EventSub established");
 
-                    let to_restore: Vec<_> = {
-                        let mut map = self.subscriptions.lock().await;
+                    let drained = self.subscriptions.drain().await;
 
-                        if !map.is_empty() {
-                            tracing::info!("Restoring {} subscriptions", map.len());
-                        }
+                    if !drained.is_empty() {
+                        tracing::info!("Restoring {} subscriptions", drained.len());
+                    }
 
-                        map.drain()
-                            .filter_map(|(key, sub)| {
-                                let (username, _) = key.split_once(':')?;
-                                Some((username.to_string(), sub.kind, sub.condition))
-                            })
-                            .collect()
-                    };
+                    let to_restore: Vec<_> = drained
+                        .into_iter()
+                        .filter_map(|(key, sub)| {
+                            let (username, _) = key.split_once(':')?;
+                            Some((username.to_string(), sub.kind, sub.condition))
+                        })
+                        .collect();
 
                     self.subscribe(
                         self.token.login.as_str(),
@@ -336,9 +333,8 @@ impl EventSubClient {
                 );
 
                 self.subscriptions
-                    .lock()
-                    .await
-                    .remove(&payload.subscription.kind.to_string());
+                    .remove_raw(&payload.subscription.kind.to_string())
+                    .await;
             }
             Ws::Keepalive => (),
         }
@@ -372,11 +368,7 @@ impl EventSubClient {
     }
 
     pub fn connected(&self) -> bool {
-        self.connected.load(Ordering::Relaxed)
-    }
-
-    fn set_connected(&self, value: bool) {
-        self.connected.store(value, Ordering::Relaxed);
+        self.state.connected()
     }
 
     #[tracing::instrument(name = "eventsub_subscribe", skip(self, condition), fields(%condition))]
@@ -386,9 +378,7 @@ impl EventSubClient {
         event: EventType,
         condition: serde_json::Value,
     ) -> Result<(), Error> {
-        let session_id = self.session_id.lock().await.clone();
-
-        let Some(session_id) = session_id else {
+        let Some(session_id) = self.state.session_id().await else {
             return Err(Error::Generic(anyhow!("No EventSub connection")));
         };
 
@@ -414,14 +404,17 @@ impl EventSubClient {
             .json()
             .await?;
 
-        self.subscriptions.lock().await.insert(
-            format!("{username}:{event}"),
-            Subscription {
-                id: response.data.0.id.take(),
-                kind: event,
-                condition,
-            },
-        );
+        self.subscriptions
+            .insert(
+                username,
+                &event.to_string(),
+                Subscription {
+                    id: response.data.0.id.take(),
+                    kind: event,
+                    condition,
+                },
+            )
+            .await;
 
         tracing::trace!("Subscription created");
 
@@ -452,8 +445,7 @@ impl EventSubClient {
         channel: &str,
         event: &str,
     ) -> Result<Option<Subscription>, Error> {
-        let key = format!("{channel}:{event}");
-        let subscription = self.subscriptions.lock().await.remove(&key);
+        let subscription = self.subscriptions.remove(channel, event).await;
 
         if let Some(ref sub) = subscription {
             self.helix
@@ -468,16 +460,7 @@ impl EventSubClient {
         &self,
         channel: &str,
     ) -> Result<Vec<(EventType, serde_json::Value)>, Error> {
-        let prefix = format!("{channel}:");
-
-        let events: Vec<String> = {
-            let subscriptions = self.subscriptions.lock().await;
-
-            subscriptions
-                .keys()
-                .filter_map(|k| k.strip_prefix(&prefix).map(String::from))
-                .collect()
-        };
+        let events = self.subscriptions.events_for_channel(channel).await;
 
         let futures = events.iter().map(|event| self.unsubscribe(channel, event));
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ mod json;
 mod log;
 mod server;
 mod seventv;
+mod ws;
 
 const CLIENT_ID: &str = "kimne78kx3ncx6brgo4mv6wki5h1ko";
 

--- a/src-tauri/src/seventv/client.rs
+++ b/src-tauri/src/seventv/client.rs
@@ -1,6 +1,3 @@
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
-
 use anyhow::anyhow;
 use futures::future::join_all;
 use futures::{SinkExt, StreamExt};
@@ -11,6 +8,7 @@ use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
 
 use crate::error::Error;
+use crate::ws::{ConnectionState, SubscriptionStore};
 
 const SEVENTV_WS_URI: &str = "wss://events.7tv.io/v3";
 
@@ -21,10 +19,9 @@ struct WebSocketMessage {
 }
 
 pub struct SeventTvClient {
-    session_id: Mutex<Option<String>>,
-    subscriptions: Mutex<HashMap<String, serde_json::Value>>,
+    state: ConnectionState,
+    subscriptions: SubscriptionStore<serde_json::Value>,
     sender: mpsc::UnboundedSender<serde_json::Value>,
-    connected: AtomicBool,
     message_tx: mpsc::UnboundedSender<Message>,
     message_rx: Mutex<Option<mpsc::UnboundedReceiver<Message>>>,
 }
@@ -35,10 +32,9 @@ impl SeventTvClient {
         let (message_tx, message_rx) = mpsc::unbounded_channel();
 
         let client = Self {
-            subscriptions: Mutex::new(HashMap::new()),
-            session_id: Mutex::new(None),
+            subscriptions: SubscriptionStore::new(),
+            state: ConnectionState::new(),
             sender,
-            connected: AtomicBool::default(),
             message_tx,
             message_rx: Mutex::new(Some(message_rx)),
         };
@@ -68,26 +64,22 @@ impl SeventTvClient {
 
             tracing::info!("Connected to 7TV Event API");
 
-            {
-                let session_id = self.session_id.lock().await;
+            if let Some(id) = self.state.session_id().await {
+                tracing::info!(%id, "Resuming 7TV session");
 
-                if let Some(id) = &*session_id {
-                    tracing::info!(%id, "Resuming 7TV session");
-
-                    let payload = json!({
-                        "op": 34,
-                        "d": {
-                            "session_id": id
-                        }
-                    });
-
-                    if let Err(err) = stream.send(Message::Text(payload.to_string().into())).await {
-                        tracing::error!(%err, "Error sending resume message");
+                let payload = json!({
+                    "op": 34,
+                    "d": {
+                        "session_id": id
                     }
+                });
+
+                if let Err(err) = stream.send(Message::Text(payload.to_string().into())).await {
+                    tracing::error!(%err, "Error sending resume message");
                 }
             }
 
-            self.connected.store(true, Ordering::Relaxed);
+            self.state.set_connected(true);
 
             loop {
                 tokio::select! {
@@ -128,7 +120,7 @@ impl SeventTvClient {
                 }
             }
 
-            self.connected.store(false, Ordering::Relaxed);
+            self.state.set_connected(false);
         }
     }
 
@@ -141,7 +133,7 @@ impl SeventTvClient {
             }
             1 => {
                 if let Some(id) = msg.d["session_id"].as_str() {
-                    *self.session_id.lock().await = Some(id.to_string());
+                    self.state.set_session_id(Some(id.to_string())).await;
                     tracing::info!(%id, "Hello received, session established");
                 }
             }
@@ -149,16 +141,12 @@ impl SeventTvClient {
                 tracing::debug!(payload = ?msg.d.to_string(), "Opcode acknowledged");
 
                 if let Some(false) = msg.d["data"]["success"].as_bool() {
-                    let to_restore: Vec<_> = {
-                        let mut subscriptions = self.subscriptions.lock().await;
+                    tracing::warn!(
+                        "Resume unsuccessful, restoring {} events",
+                        self.subscriptions.len().await
+                    );
 
-                        tracing::warn!(
-                            "Resume unsuccessful, restoring {} events",
-                            subscriptions.len()
-                        );
-
-                        subscriptions.drain().collect()
-                    };
+                    let to_restore = self.subscriptions.drain().await;
 
                     for (key, condition) in to_restore {
                         let Some((channel, event)) = key.split_once(':') else {
@@ -178,7 +166,7 @@ impl SeventTvClient {
     }
 
     pub fn connected(&self) -> bool {
-        self.connected.load(Ordering::Relaxed)
+        self.state.connected()
     }
 
     #[tracing::instrument(name = "7tv_subscribe", skip(self, condition), fields(%condition))]
@@ -197,9 +185,8 @@ impl SeventTvClient {
         {
             Ok(_) => {
                 self.subscriptions
-                    .lock()
-                    .await
-                    .insert(format!("{channel}:{event}"), condition.clone());
+                    .insert(channel, event, condition.clone())
+                    .await;
 
                 tracing::trace!("Subscription created");
             }
@@ -210,9 +197,7 @@ impl SeventTvClient {
     }
 
     pub async fn unsubscribe(&self, channel: &str, event: &str) {
-        let mut subscriptions = self.subscriptions.lock().await;
-
-        if let Some(condition) = subscriptions.remove(&format!("{channel}:{event}")) {
+        if let Some(condition) = self.subscriptions.remove(channel, event).await {
             let payload = json!({
                 "op": 36,
                 "d": {
@@ -228,17 +213,7 @@ impl SeventTvClient {
     }
 
     pub async fn unsubscribe_all(&self, channel: &str) {
-        let prefix = format!("{channel}:");
-
-        let events: Vec<String> = {
-            let subscriptions = self.subscriptions.lock().await;
-
-            subscriptions
-                .keys()
-                .filter_map(|k| k.strip_prefix(&prefix).map(String::from))
-                .collect()
-        };
-
+        let events = self.subscriptions.events_for_channel(channel).await;
         let futures = events.iter().map(|event| self.unsubscribe(channel, event));
 
         join_all(futures).await;

--- a/src-tauri/src/seventv/client.rs
+++ b/src-tauri/src/seventv/client.rs
@@ -141,12 +141,12 @@ impl SeventTvClient {
                 tracing::debug!(payload = ?msg.d.to_string(), "Opcode acknowledged");
 
                 if let Some(false) = msg.d["data"]["success"].as_bool() {
+                    let to_restore = self.subscriptions.drain().await;
+
                     tracing::warn!(
                         "Resume unsuccessful, restoring {} events",
-                        self.subscriptions.len().await
+                        to_restore.len()
                     );
-
-                    let to_restore = self.subscriptions.drain().await;
 
                     for (key, condition) in to_restore {
                         let Some((channel, event)) = key.split_once(':') else {

--- a/src-tauri/src/ws.rs
+++ b/src-tauri/src/ws.rs
@@ -1,0 +1,107 @@
+//! Shared building blocks for websocket subscription clients.
+//!
+//! Both `eventsub::client` and `seventv::client` maintain the same shape of
+//! state: a session id, an `AtomicBool` for the connected flag, and a
+//! `HashMap` of subscriptions keyed by `"channel:event"`. The subscription
+//! semantics differ enough (Twitch EventSub subscribes over HTTP, 7TV over
+//! websocket frames) that a full `Protocol` trait would require a tangle of
+//! associated types and `Box<dyn>`s. Instead this module exposes small
+//! building blocks the two clients compose.
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tokio::sync::Mutex;
+
+/// Build the canonical `"channel:event"` key used by both clients.
+pub fn sub_key(channel: &str, event: &str) -> String {
+    format!("{channel}:{event}")
+}
+
+/// Connection-level state shared by every websocket subscription client.
+#[derive(Debug, Default)]
+pub struct ConnectionState {
+    pub session_id: Mutex<Option<String>>,
+    pub connected: AtomicBool,
+}
+
+impl ConnectionState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn connected(&self) -> bool {
+        self.connected.load(Ordering::Relaxed)
+    }
+
+    pub fn set_connected(&self, value: bool) {
+        self.connected.store(value, Ordering::Relaxed);
+    }
+
+    pub async fn set_session_id(&self, id: Option<String>) {
+        *self.session_id.lock().await = id;
+    }
+
+    pub async fn session_id(&self) -> Option<String> {
+        self.session_id.lock().await.clone()
+    }
+}
+
+/// HashMap of subscriptions keyed by `"channel:event"`.
+///
+/// `V` is whatever per-subscription state the protocol needs (e.g. an opaque
+/// remote id plus condition for EventSub, just the condition for 7TV).
+#[derive(Debug)]
+pub struct SubscriptionStore<V> {
+    inner: Mutex<HashMap<String, V>>,
+}
+
+impl<V> Default for SubscriptionStore<V> {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl<V> SubscriptionStore<V> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn insert(&self, channel: &str, event: &str, value: V) {
+        self.inner
+            .lock()
+            .await
+            .insert(sub_key(channel, event), value);
+    }
+
+    pub async fn remove(&self, channel: &str, event: &str) -> Option<V> {
+        self.inner.lock().await.remove(&sub_key(channel, event))
+    }
+
+    pub async fn remove_raw(&self, key: &str) -> Option<V> {
+        self.inner.lock().await.remove(key)
+    }
+
+    /// Drain every subscription, returning them as `(key, value)` pairs.
+    pub async fn drain(&self) -> Vec<(String, V)> {
+        self.inner.lock().await.drain().collect()
+    }
+
+    pub async fn len(&self) -> usize {
+        self.inner.lock().await.len()
+    }
+
+    /// Collect every event suffix (the part after the `channel:` prefix) for
+    /// a given channel. Used by `unsubscribe_all` in both clients.
+    pub async fn events_for_channel(&self, channel: &str) -> Vec<String> {
+        let prefix = format!("{channel}:");
+
+        self.inner
+            .lock()
+            .await
+            .keys()
+            .filter_map(|k| k.strip_prefix(&prefix).map(String::from))
+            .collect()
+    }
+}

--- a/src-tauri/src/ws.rs
+++ b/src-tauri/src/ws.rs
@@ -79,17 +79,21 @@ impl<V> SubscriptionStore<V> {
         self.inner.lock().await.remove(&sub_key(channel, event))
     }
 
-    pub async fn remove_raw(&self, key: &str) -> Option<V> {
-        self.inner.lock().await.remove(key)
+    pub async fn remove_by<F>(&self, mut predicate: F) -> Option<V>
+    where
+        F: FnMut(&V) -> bool,
+    {
+        let mut map = self.inner.lock().await;
+        let key = map
+            .iter()
+            .find_map(|(k, v)| predicate(v).then(|| k.clone()))?;
+
+        map.remove(&key)
     }
 
     /// Drain every subscription, returning them as `(key, value)` pairs.
     pub async fn drain(&self) -> Vec<(String, V)> {
         self.inner.lock().await.drain().collect()
-    }
-
-    pub async fn len(&self) -> usize {
-        self.inner.lock().await.len()
     }
 
     /// Collect every event suffix (the part after the `channel:` prefix) for


### PR DESCRIPTION
Both `eventsub::client` and `seventv::client` carried the same state and the same drain-and-
restore logic. This lifts only the duplicated state and key bookkeeping into a `ws` module via `ConnectionState` and `SubscriptionStore<V>`.

Assisted by Claude.